### PR TITLE
Fix raw html links

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,8 @@ all: fixed_source fixed_xml
 	$(MAKE) ptx post fixed_ptx build_$(TARGET)
 
 fixed_source:
-	find _sources/ -name '*.rst' -exec ./fix-source.pl {} \;
 	find _sources/ -name '*.rst' -exec ./fix-raw-html-links.pl {} \;
+	find _sources/ -name '*.rst' -exec ./fix-source.pl {} \;
 
 xml:
 	$(rs2ptx)

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ all: fixed_source fixed_xml
 
 fixed_source:
 	find _sources/ -name '*.rst' -exec ./fix-source.pl {} \;
+	find _sources/ -name '*.rst' -exec ./fix-raw-html-links.pl {} \;
 
 xml:
 	$(rs2ptx)

--- a/_sources/Unit0-Getting-Started/aboutcsa.rst
+++ b/_sources/Unit0-Getting-Started/aboutcsa.rst
@@ -11,7 +11,7 @@ response questions where you have to write Java code by hand. Each part is worth
 50% of your grade. During the exam, you will have access to the |AP CSA
 Reference Sheet|.
 
-The 4 free response questions cover the following areas (from |AP CSA Free Response|):
+The 4 free response questions cover the following areas (from `AP CSA Free Response <https://apstudents.collegeboard.org/courses/ap-computer-science-a/assessment>`_):
 
   - **Question 1**: Methods and Control Structures—You’ll be asked to write program
     code to create objects of a class and call methods, and satisfy method
@@ -66,46 +66,23 @@ lab time for you to practice Java programming.
    10      Recursion               5–7.5%          3-5
    ======= ======================= =============== ========== ========
 
-For more information on the exam see the College Board |AP CSA site| and the
-200+ page |AP CSA CED|. The |AP CSA past FRQs| are available online. Here is an
-|FRQ resource| that categorizes the past FRQs by topic and provides links to
+For more information on the exam see the College Board `AP CSA site <https://apstudent.collegeboard.org/apcourse/ap-computer-science-a>`_ and the
+200+ page `AP CSA Course and Exam Description (CED) <https://apcentral.collegeboard.org/pdf/ap-computer-science-a-course-and-exam-description.pdf?course=ap-computer-science-a>`_. The `AP CSA Past Free Response Questions <https://apstudents.collegeboard.org/courses/ap-computer-science-a/free-response-questions-by-year>`_ are available online. Here is an
+`FRQ resource <https://docs.google.com/spreadsheets/d/1Q0pbL9qawN8XlUctkDIiqsP6XdwR-IcWZ_cwauHy0-U/edit?usp=sharing>`_ that categorizes the past FRQs by topic and provides links to
 their solutions (which are available online in many places). The College Board
 provides a question bank and formative assessment quizzes for each unit online
 for registered AP classes.
 
-Also check out this list of |CS Careers| that taking CSA can lead to. Learning
+Also check out this list of `CS Careers <https://apstudents.collegeboard.org/choosing-courses/major-career-results/course/AP-Computer-Science-A>`_ that taking CSA can lead to. Learning
 to code is an increasingly important skill that has applications in many
 careers!
 
 
-.. |AP CSA site| raw:: html
 
-   <a href="https://apstudent.collegeboard.org/apcourse/ap-computer-science-a" target="_blank">AP CSA site</a>
 
-.. |AP CSA CED| raw:: html
 
-   <a href="https://apcentral.collegeboard.org/pdf/ap-computer-science-a-course-and-exam-description.pdf?course=ap-computer-science-a" target="_blank">AP CSA Course and Exam Description (CED)</a>
 
-.. |CS Careers| raw:: html
 
-   <a href="https://apstudents.collegeboard.org/choosing-courses/major-career-results/course/AP-Computer-Science-A" target="_blank">CS Careers</a>
 
-.. |AP CSA Reference Sheet| raw:: html
 
-   <a href="https://apstudents.collegeboard.org/ap/pdf/ap-computer-science-a-java-quick-reference_0.pdf" target="_blank">AP CSA Java Quick Reference Sheet</a>
 
-.. |AP CSA past FRQs| raw:: html
-
-   <a href="https://apstudents.collegeboard.org/courses/ap-computer-science-a/free-response-questions-by-year" target="_blank">AP CSA Past Free Response Questions</a>
-
-.. |FRQ resource| raw:: html
-
-   <a href="https://docs.google.com/spreadsheets/d/1Q0pbL9qawN8XlUctkDIiqsP6XdwR-IcWZ_cwauHy0-U/edit?usp=sharing" target="_blank">FRQ resource</a>
-
-.. |AP Audit|  raw:: html
-
-   <a href="https://apcentral.collegeboard.org/courses/ap-course-audit" target="_blank">AP Audit</a>
-
-.. |AP CSA Free Response|  raw:: html
-
-   <a href="https://apstudents.collegeboard.org/courses/ap-computer-science-a/assessment" target="_blank">AP CSA Free Response</a>

--- a/_sources/Unit0-Getting-Started/csptransition.rst
+++ b/_sources/Unit0-Getting-Started/csptransition.rst
@@ -43,21 +43,15 @@ your prior programming experience was with a block language:
   activities to make sure they match. Get in the habit of clicking it frequently
   to keep your code tidy.
 
-.. |open in Google Docs| raw:: html
 
-   <a href="https://docs.google.com/document/d/1xhSAfzF1pH0nlUL94lmpdvd8fO4sa38cOuunXnJU4Bs/view" target="_blank">open in Google Docs</a>
 
-.. |code.org App Lab code to Java| raw:: html
-
-   <a href="https://docs.google.com/document/d/1LB6a36tRKGgTGJUcpT_3TspXFqn5luu1YU8YmYt1CQs/edit?usp=sharing" target="_blank">code.org App Lab code to Java</a>
-
-Here is a comparison of some App Inventor blocks compared to AP CSP pseudocode and Java code used in AP CSA (|open in Google Docs|).
+Here is a comparison of some App Inventor blocks compared to AP CSP pseudocode and Java code used in AP CSA (`open in Google Docs <https://docs.google.com/document/d/1xhSAfzF1pH0nlUL94lmpdvd8fO4sa38cOuunXnJU4Bs/view>`_).
 
 .. raw:: html
 
     <iframe src="https://docs.google.com/document/d/1xhSAfzF1pH0nlUL94lmpdvd8fO4sa38cOuunXnJU4Bs/view" style="max-width:100%; margin-left:5%; width:90%;"  height="600px"></iframe>
 
-And here is a a comparison of |code.org App Lab code to Java|:
+And here is a a comparison of `code.org App Lab code to Java <https://docs.google.com/document/d/1LB6a36tRKGgTGJUcpT_3TspXFqn5luu1YU8YmYt1CQs/edit?usp=sharing>`_:
 
 .. raw:: html
 

--- a/_sources/Unit0-Getting-Started/growthMindset.rst
+++ b/_sources/Unit0-Getting-Started/growthMindset.rst
@@ -9,11 +9,8 @@ Growth Mindset
 
 Learning to code can be hard at times and sometimes frustrating. However, the feeling you get when your code works is incredible! And your brain grows as you problem solve and debug your programs!
 
-Watch this |video| about the Growth Mindset:
+Watch this `video <https://youtu.be/WtKJrB5rOKs>`_ about the Growth Mindset:
 
-.. |video| raw:: html
-
-   <a href="https://youtu.be/WtKJrB5rOKs" target="_blank">video</a>
 
 .. youtube:: WtKJrB5rOKs
     :height: 400
@@ -51,11 +48,8 @@ Pair Programming
 
 In this curriculum, you are encouraged to work together in pairs to complete the programming challenges. **Pair programming** is a successful software development technique where two programmers work together at one computer. One, the driver, types in code while the other, the navigator, gives ideas and feedback. The two coders switch roles frequently. You can also try buddy programming where each person uses their own computer but helps each other while coding. The advantages of pair programming are that two heads are better than one, and pairs usually produce better code with less roadblocks. As future software developers, it's also important to learn to work in teams.
 
-Watch this |video2| about pair programming:
+Watch this `video <https://www.youtube.com/watch?v=q7d_JtyCq1A>`_ about pair programming:
 
-.. |video2| raw:: html
-
-   <a href="https://www.youtube.com/watch?v=q7d_JtyCq1A" target="_blank">video</a>
 
 .. youtube:: q7d_JtyCq1A
     :height: 400

--- a/_sources/Unit0-Getting-Started/preface.rst
+++ b/_sources/Unit0-Getting-Started/preface.rst
@@ -106,11 +106,8 @@ Many others have been involved in the creation of content for the eBook (includi
 .. figure:: https://i.creativecommons.org/l/by-nc-sa/4.0/88x31.png
    :align: center
 
-.. |creative commons| raw:: html
 
-   <a href="http://creativecommons.org/licenses/by-nc-sa/4.0/" target="_blank" style="text-decoration:underline">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License</a>
-
-This work is licensed under a |creative commons|.
+This work is licensed under a `Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License <http://creativecommons.org/licenses/by-nc-sa/4.0/>`_.
 
 Barbara Ericson `barbarer@umich.edu <mailto://barbarer@umich.edu>`_
 2014-2024

--- a/_sources/Unit0-Getting-Started/survey.rst
+++ b/_sources/Unit0-Getting-Started/survey.rst
@@ -14,11 +14,8 @@ If you have questions please email Barbara Ericson (barbarer@umich.edu).
 Survey
 ======
 
-.. |Privacy Policy| raw:: html
 
-   <a href="https://runestone.academy/runestone/default/privacy" target="_blank" style="text-decoration:underline">Runestone Academy Privacy Policy</a>
-
-Please log into Runestone and fill out the following survey.  You do not have to answer any of the following questions, but if you do, it will give us valuable information about who is using this ebook. Your answers to all questions on this site will be used for educational research and to improve the ebook.  Any identifying information, such as your name, will be removed from the data before it is analyzed and used in publications (|Privacy Policy|).
+Please log into Runestone and fill out the following survey.  You do not have to answer any of the following questions, but if you do, it will give us valuable information about who is using this ebook. Your answers to all questions on this site will be used for educational research and to improve the ebook.  Any identifying information, such as your name, will be removed from the data before it is analyzed and used in publications (`Runestone Academy Privacy Policy <https://runestone.academy/runestone/default/privacy>`_).
 
 .. qnum::
    :prefix: 1-1-7-

--- a/_sources/Unit1-Using-Objects-and-Methods/JavaSwingGUIs.rst
+++ b/_sources/Unit1-Using-Objects-and-Methods/JavaSwingGUIs.rst
@@ -5,17 +5,7 @@
    :start: 1
 
 
-.. |repl| raw:: html
 
-   <a href="https://replit.com" target="_blank" style="text-decoration:underline">replit</a>
-
-.. |Java Swing Example| raw:: html
-
-   <a href="https://replit.com/@BerylHoffman/JavaSwingHello#Main.java" target="_blank" style="text-decoration:underline">Java Swing Example</a>
-
-.. |JButton Class| raw:: html
-
-   <a href="https://www.javatpoint.com/java-jbutton" target="_blank" style="text-decoration:underline">JButton Class</a>
 
 
 Java Swing GUIs (optional)
@@ -46,7 +36,7 @@ To set up a JFrame window for your UI, declare an object of type JFrame, set its
     frame.setLayout(null);
     frame.setVisible(true); // usually at the end of the main method
 
-Once you have a JFrame, you can create graphical objects like buttons and labels and add them to the JFrame. You can look up more information about these Java Swing Components and what methods they have. For example, here's more information on the |JButton Class|.
+Once you have a JFrame, you can create graphical objects like buttons and labels and add them to the JFrame. You can look up more information about these Java Swing Components and what methods they have. For example, here's more information on the `JButton Class <https://www.javatpoint.com/java-jbutton>`_.
 
 .. code-block:: java
 
@@ -58,11 +48,11 @@ Once you have a JFrame, you can create graphical objects like buttons and labels
 
 If you set the layout of the frame to null, you must use ``setBounds(x position, y position, width, height)`` for each component to set their position and size on the frame. Remember that the top left corner has the (x,y) coordinates (0,0). The bottom right corner coordinates are the size of your frame, for example (500,500). The width 100 and the height 50 are good sizes for most components. Some Java IDEs have GUI Visual Designers where you can drag and drop in and resize components.
 
-In |repl|, there is no GUI designer available, but it can display Java Swing GUIs. When creating a new repl, you can choose Java Swing as the file type, instead of just Java, to use a Java Swing UI.
+In `replit <https://replit.com>`_, there is no GUI designer available, but it can display Java Swing GUIs. When creating a new repl, you can choose Java Swing as the file type, instead of just Java, to use a Java Swing UI.
 
 |CodingEx| **Coding Exercise**
 
-Here's a |Java Swing Example| on repl that sets up a ``JFrame`` with a ``JButton`` and a ``JLabel``. It calls a special method called ``addActionListener`` where you can put the code to be executed when you click on a button. Can you add another button to it? Remember that you will need to create a ``JButton`` object, call ``setBounds`` on it, and add it to the frame. Copy the ``addActionListener`` code and change it to work for your new button to say “Good Bye” instead of “hello”.
+Here's a `Java Swing Example <https://replit.com/@BerylHoffman/JavaSwingHello#Main.java>`_ on repl that sets up a ``JFrame`` with a ``JButton`` and a ``JLabel``. It calls a special method called ``addActionListener`` where you can put the code to be executed when you click on a button. Can you add another button to it? Remember that you will need to create a ``JButton`` object, call ``setBounds`` on it, and add it to the frame. Copy the ``addActionListener`` code and change it to work for your new button to say “Good Bye” instead of “hello”.
 
 .. raw:: html
 

--- a/_sources/Unit1-Using-Objects-and-Methods/topic-1-1-intro-algorithms.rst
+++ b/_sources/Unit1-Using-Objects-and-Methods/topic-1-1-intro-algorithms.rst
@@ -278,16 +278,9 @@ Syntax Errors and Debugging
 
 Computers don't actually speak Java so we have to **compile** (translate) Java source files that we write into class files which is code that a computer can understand and run. In this e-book, the Java code is actually being sent to a Java server to compile and run, and the output is sent back to show on the same page.
 
-.. |Grace Hopper| raw:: html
-
-   <a href="https://en.wikipedia.org/wiki/Grace_Hopper" target="_blank">Grace Hopper</a>
-
-.. |Rubber duck debugging| raw:: html
-
-   <a href="https://rubberduckdebugging.com/" target="_blank">Rubber duck debugging</a>
 
 
-**Syntax errors** are reported to you by the compiler if your Java code is not correctly written. Examples of syntax errors are a semicolon ``;`` missing or if the code has a open curly brace ``{`` or open quote ``"``, but no close curly brace ``}`` or close quote ``"``. Informally, a syntax error is called a **bug**, and the process of removing errors is called **debugging**. An early computer science pioneer |Grace Hopper| documented a real bug, a moth that flew into a computer in 1947!
+**Syntax errors** are reported to you by the compiler if your Java code is not correctly written. Examples of syntax errors are a semicolon ``;`` missing or if the code has a open curly brace ``{`` or open quote ``"``, but no close curly brace ``}`` or close quote ``"``. Informally, a syntax error is called a **bug**, and the process of removing errors is called **debugging**. An early computer science pioneer `Grace Hopper <https://en.wikipedia.org/wiki/Grace_Hopper>`_ documented a real bug, a moth that flew into a computer in 1947!
 
 .. figure:: Figures/firstbug.jpg
     :width: 300px
@@ -299,7 +292,7 @@ Computers don't actually speak Java so we have to **compile** (translate) Java s
 
 The compiler tries to run your code, but if your code has **syntax errors**, you will see error messages displayed below the code. Compiler error messages will tell the line number that the compiler found the error and the type of error.  The error messages are not always easy to understand and sometimes the actual error is before the line that the compiler says is the problem.
 
-Watch the following video to see that all coders get bugs. Debugging is a normal part of coding. It can be frustrating at times, but you will get better at it with practice! Sometimes another pair of eyes really helps, so ask a friend if you get stuck or try explaining your code line by line to someone or even a rubber duck. |Rubber duck debugging| is a lot of fun!
+Watch the following video to see that all coders get bugs. Debugging is a normal part of coding. It can be frustrating at times, but you will get better at it with practice! Sometimes another pair of eyes really helps, so ask a friend if you get stuck or try explaining your code line by line to someone or even a rubber duck. `Rubber duck debugging <https://rubberduckdebugging.com/>`_ is a lot of fun!
 
 .. youtube:: auv10y-dN4s
     :width: 700px
@@ -579,7 +572,7 @@ working with you. Here are some examples of good commenting:
     :align: left
     :alt: Rubber Duck
 
-In this course, you are encouraged to work together in pairs to complete the programming challenges. Pair programming is a successful software development technique where two programmers work together at one computer. One, the driver, types in code while the other, the navigator, gives ideas and feedback. The two coders switch roles frequently. Another option is buddy programming, where two or three coders work on their own computers but help each other as needed. If you're working alone, you may want to explain the code to a rubber duck or another toy using |Rubber duck debugging|.
+In this course, you are encouraged to work together in pairs to complete the programming challenges. Pair programming is a successful software development technique where two programmers work together at one computer. One, the driver, types in code while the other, the navigator, gives ideas and feedback. The two coders switch roles frequently. Another option is buddy programming, where two or three coders work on their own computers but help each other as needed. If you're working alone, you may want to explain the code to a rubber duck or another toy using `Rubber duck debugging <https://rubberduckdebugging.com/>`_.
 
 Working in pairs, debug the following code. Can you find all the bugs and get the code to run?
 

--- a/_sources/Unit1-Using-Objects-and-Methods/topic-1-11-Math.rst
+++ b/_sources/Unit1-Using-Objects-and-Methods/topic-1-11-Math.rst
@@ -30,17 +30,9 @@ This is why we can just say Math.random() instead of having to define an object 
 Mathematical Functions
 -----------------------
 
-.. |AP CSA Reference Sheet| raw:: html
-
-   <a href="https://apstudents.collegeboard.org/ap/pdf/ap-computer-science-a-java-quick-reference_0.pdf" target="_blank">AP CSA Java Quick Reference Sheet</a>
-
-.. |Math class Javadocs| raw:: html
-
-   <a href="https://docs.oracle.com/javase/8/docs/api/java/lang/Math.html" target="_blank">Math class Javadocs</a>
 
 
-
-The ``Math`` class contains the following methods that are in the AP CSA subset. There are more ``Math`` methods, outside of what you need on the AP exam, that you can find in the |Math class Javadocs|.
+The ``Math`` class contains the following methods that are in the AP CSA subset. There are more ``Math`` methods, outside of what you need on the AP exam, that you can find in the `Math class Javadocs <https://docs.oracle.com/javase/8/docs/api/java/lang/Math.html>`_.
 
 - ``int abs(int)`` : Returns the absolute value of an int value (which is the value of a number without its sign, for example ``Math.abs(-4)`` = 4).
 
@@ -56,7 +48,7 @@ The ``Math`` class contains the following methods that are in the AP CSA subset.
 .. note::
 
    All the ``Math`` methods that you may need to use or understand on the AP
-   exam are listed in the |AP CSA Reference Sheet| that you can use during the
+   exam are listed in the `AP CSA Java Quick Reference Sheet <https://apstudents.collegeboard.org/ap/pdf/ap-computer-science-a-java-quick-reference_0.pdf>`_ that you can use during the
    exam.
 
 These Math methods are mathematical functions that compute new values from their arguments. You may be able to guess what ``abs``, ``pow``, and ``sqrt`` do, from their abbreviations. 

--- a/_sources/Unit1-Using-Objects-and-Methods/topic-1-12-objects.rst
+++ b/_sources/Unit1-Using-Objects-and-Methods/topic-1-12-objects.rst
@@ -6,13 +6,6 @@
 
 ..  |Time45|
 
-.. |repl link| raw:: html
-
-   <a href="https://replit.com/@BerylHoffman/Java-Swing-Turtle#Main.java" target="_blank" style="text-decoration:underline">replit link</a>
-
-.. |github| raw:: html
-
-   <a href="https://github.com/bhoffman0/CSAwesome/raw/master/_sources/Unit2-Using-Objects/TurtleJavaSwingCode.zip" target="_blank" style="text-decoration:underline">here</a>
 
 
 Objects - Instances of Classes
@@ -87,11 +80,8 @@ playing (*behavior*).
     behaviors of cats? (Note that attributes are often nouns or adjectives
     describing features of cats, and behaviors are often verbs).
 
-.. |video1| raw:: html
 
-   <a href="https://www.youtube.com/watch?v=64DOwDu5SVo&list=PLHqz-wcqDQIEP6p1_0wOb9l9aQ0qFijrP&ab_channel=colleenlewis" target="_blank">video</a>
-
-Watch the following |video1| by Dr. Colleen Lewis about classes and objects:
+Watch the following `video <https://www.youtube.com/watch?v=64DOwDu5SVo&list=PLHqz-wcqDQIEP6p1_0wOb9l9aQ0qFijrP&ab_channel=colleenlewis>`_ by Dr. Colleen Lewis about classes and objects:
 
 .. youtube:: 64DOwDu5SVo
     :optional:
@@ -169,7 +159,7 @@ The Turtle class (that we've written for you and hidden on this page) is a bluep
     :datafile: turtleClasses.jar
 
     Try clicking the run button below to see what the following program does.
-    (If the code below does not work or is too slow in your browser, you can also see the ``Turtle`` code in action at this |repl link| (refresh page after forking and if it gets stuck) or download the files |github| to use in your own IDE.)
+    (If the code below does not work or is too slow in your browser, you can also see the ``Turtle`` code in action at this `replit link <https://replit.com/@BerylHoffman/Java-Swing-Turtle#Main.java>`_ (refresh page after forking and if it gets stuck) or download the files `here <https://github.com/bhoffman0/CSAwesome/raw/master/_sources/Unit2-Using-Objects/TurtleJavaSwingCode.zip>`_ to use in your own IDE.)
     ~~~~
     import java.awt.*;
     import java.util.*;
@@ -211,11 +201,8 @@ The Turtle class (that we've written for you and hidden on this page) is a bluep
         }
     }
 
-.. |video2| raw:: html
 
-   <a href="https://www.youtube.com/watch?v=TFmmG4_KK8I&list=PLHqz-wcqDQIEP6p1_0wOb9l9aQ0qFijrP&ab_channel=colleenlewis" target="_blank">video</a>
-
-The following |video2| shows how the program creates a ``World`` object called ``habitat`` and a ``Turtle`` object called ``yertle`` in memory.
+The following `video <https://www.youtube.com/watch?v=TFmmG4_KK8I&list=PLHqz-wcqDQIEP6p1_0wOb9l9aQ0qFijrP&ab_channel=colleenlewis>`_ shows how the program creates a ``World`` object called ``habitat`` and a ``Turtle`` object called ``yertle`` in memory.
 
 .. youtube:: TFmmG4_KK8I
     :width: 650px
@@ -632,11 +619,8 @@ Summary
 AP Practice
 ------------
 
-.. |video3| raw:: html
 
-   <a href="https://www.youtube.com/watch?v=Y9vn6u3901Y&list=PLHqz-wcqDQIEP6p1_0wOb9l9aQ0qFijrP&ab_channel=colleenlewis" target="_blank">video</a>
-
-This |video3| shows another class called Belt and how it has 3 instance variables to define its attributes. Every belt object has its own copy of instance variables.
+This `video <https://www.youtube.com/watch?v=Y9vn6u3901Y&list=PLHqz-wcqDQIEP6p1_0wOb9l9aQ0qFijrP&ab_channel=colleenlewis>`_ shows another class called Belt and how it has 3 instance variables to define its attributes. Every belt object has its own copy of instance variables.
 
 .. youtube:: Y9vn6u3901Y
     :width: 650px

--- a/_sources/Unit1-Using-Objects-and-Methods/topic-1-13-constructors.rst
+++ b/_sources/Unit1-Using-Objects-and-Methods/topic-1-13-constructors.rst
@@ -7,13 +7,7 @@
 .. index::
    pair: class; constructor
 
-.. |repl link| raw:: html
 
-   <a href="https://replit.com/@BerylHoffman/Java-Swing-Turtle#Main.java" target="_blank" style="text-decoration:underline">replit.com link</a>
-
-.. |github| raw:: html
-
-   <a href="https://github.com/bhoffman0/APCSA-2019/tree/master/_sources/Unit2-Using-Objects/TurtleJavaSwingCode.zip" target="_blank" style="text-decoration:underline">here</a>
 
 ..  |Time45|
 
@@ -150,7 +144,7 @@ There is another ``Turtle`` constructor that places the turtle at a certain (x,y
 
     Try changing the code below to create a ``World`` object with 300x400 pixels. Where is the turtle placed by default? What parameters do you need to pass to the ``Turtle`` constructor to put the turtle at the top right corner? Experiment and find out. What happens if you mix up the order of the parameters?
 
-    (If the code below does not work in your browser, you can also use the ``Turtle`` code at this |repl link| (refresh page after forking and if it gets stuck) or download the files |github| to use in your own IDE.)
+    (If the code below does not work in your browser, you can also use the ``Turtle`` code at this `replit.com link <https://replit.com/@BerylHoffman/Java-Swing-Turtle#Main.java>`_ (refresh page after forking and if it gets stuck) or download the files `here <https://github.com/bhoffman0/APCSA-2019/tree/master/_sources/Unit2-Using-Objects/TurtleJavaSwingCode.zip>`_ to use in your own IDE.)
     ~~~~
     import java.awt.*;
     import java.util.*;
@@ -214,11 +208,8 @@ Object Variables and References
 
 You can also declare an **object variable** and initialize it to **null** (``Turtle t1 = null;``). An object variable holds a **reference** to an object.  A **reference** is a way to find the object in memory. It is like a tracking number that you can use to track the location of a package.
 
-.. |video1| raw:: html
 
-   <a href="https://www.youtube.com/watch?v=5fpjgXAV2BU&list=PLHqz-wcqDQIEP6p1_0wOb9l9aQ0qFijrP&ab_channel=colleenlewis" target="_blank">video</a>
-
-Watch the |video1| below about null.
+Watch the `video <https://www.youtube.com/watch?v=5fpjgXAV2BU&list=PLHqz-wcqDQIEP6p1_0wOb9l9aQ0qFijrP&ab_channel=colleenlewis>`_ below about null.
 
 .. youtube:: 5fpjgXAV2BU
     :width: 650px
@@ -241,11 +232,8 @@ The code ``Turtle t1 = null;`` creates a variable ``t1`` that refers to a ``Turt
 Constructor Signatures
 -----------------------------------
 
-.. |turtle documentation| raw:: html
 
-   <a href="https://www2.cs.uic.edu/~i101/doc/Turtle.html" target="_blank" style="text-decoration:underline">documentation</a>
-
-When you use a class that someone has already written for you in a **library** that you can import like the ``Turtle`` class above, you can look up how to use the constructors and methods in the |turtle documentation| for that class.  The documentation will list the **signatures** (or headers) of the constructors or methods which will tell you their name and parameter list. The **parameter list**, in the **header** of a constructor, lists the **formal parameters**, declaring the variables that will be passed in as values and their data types.
+When you use a class that someone has already written for you in a **library** that you can import like the ``Turtle`` class above, you can look up how to use the constructors and methods in the `documentation <https://www2.cs.uic.edu/~i101/doc/Turtle.html>`_ for that class.  The documentation will list the **signatures** (or headers) of the constructors or methods which will tell you their name and parameter list. The **parameter list**, in the **header** of a constructor, lists the **formal parameters**, declaring the variables that will be passed in as values and their data types.
 
 Constructors are **overloaded** when there are multiple constructors, but the constructors have different signatures. They can differ in the number, type, and/or order of parameters.  For example, here are two constructors for the ``Turtle`` class that take different parameters:
 
@@ -482,11 +470,8 @@ The CustomTurtle class in the ActiveCode below inherits many of its attributes a
   public CustomTurtle(int x, int y, World w, Color body, Color shell, int w, int h)
 
 
-.. |Color| raw:: html
 
-   <a href= "https://docs.oracle.com/javase/7/docs/api/java/awt/Color.html" target="_blank">Color</a>
-
-You will use the constructor(s) to create the CustomTurtles below. You can specify colors like Color.red by using the |Color| class in Java.
+You will use the constructor(s) to create the CustomTurtles below. You can specify colors like Color.red by using the `Color <https://docs.oracle.com/javase/7/docs/api/java/awt/Color.html>`_ class in Java.
 
 1. Create a large 150x200 (width 150 and height 200) CustomTurtle with a green body (Color.green) and a blue shell (Color.blue) at position (150,300)
 

--- a/_sources/Unit1-Using-Objects-and-Methods/topic-1-14-calling-instance-methods.rst
+++ b/_sources/Unit1-Using-Objects-and-Methods/topic-1-14-calling-instance-methods.rst
@@ -18,9 +18,6 @@
     :alt: run button
 
 
-.. |github| raw:: html
-
-   <a href="https://github.com/bhoffman0/APCSA-2019/tree/master/_sources/Unit2-Using-Objects/TurtleJavaSwingCode.zip" target="_blank" style="text-decoration:underline">here</a>
 
 ..  |Time45|
 
@@ -76,7 +73,7 @@ Every method call is followed by parentheses. The parentheses ``()`` after metho
 
 
 After you put the mixed up code in order above, type in the same code below to make the turtle draw a 7.
-(If the code below does not work for you, you can also use the ``Turtle`` code at this |repl link| (refresh page after forking and if it gets stuck) or download the files |github| to use in your own IDE.)
+(If the code below does not work for you, you can also use the ``Turtle`` code at this `replit.com link <https://replit.com/@BerylHoffman/Java-Swing-Turtle#Main.java>`_ (refresh page after forking and if it gets stuck) or download the files `here <https://github.com/bhoffman0/APCSA-2019/tree/master/_sources/Unit2-Using-Objects/TurtleJavaSwingCode.zip>`_ to use in your own IDE.)
 
 .. activecode:: TurtleDraw7
     :language: java
@@ -254,11 +251,8 @@ You will learn to write your own methods in Unit 5. In this unit, you should be 
     :click-incorrect:}:endclick:
 
 
-.. |visualization| raw:: html
 
-   <a href="http://www.pythontutor.com/java.html#code=public%20class%20Song%20%7B%0A%20%20%0A%20%20%20%20public%20void%20print%28%29%20%7B%0A%20%20%20%20%20%20%20%20System.out.println%28%22Old%20MacDonald%20had%20a%20farm%22%29%3B%0A%20%20%20%20%20%20%20%20chorus%28%29%3B%0A%20%20%20%20%20%20%20%20System.out.print%28%22And%20on%20that%20farm%20he%20had%20a%20%22%29%3B%0A%20%20%20%20%20%20%20%20animal%28%29%3B%0A%20%20%20%20%20%20%20%20chorus%28%29%3B%0A%20%20%20%20%7D%0A%20%20%20%20public%20void%20chorus%28%29%0A%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20System.out.println%28%22E-I-E-I-O%22%29%3B%0A%20%20%20%20%7D%0A%20%20%20%20%0A%20%20%20%20public%20void%20animal%28%29%20%7B%0A%20%20%20%20%20%20%20System.out.println%28%22duck%22%29%3B%0A%20%20%20%20%7D%0A%20%20%20%20public%20static%20void%20main%28String%5B%5D%20args%29%20%7B%0A%20%20%20%20%20%20%20Song%20s%20%3D%20new%20Song%28%29%3B%0A%20%20%20%20%20%20%20s.print%28%29%3B%0A%20%20%20%20%7D%0A%7D&cumulative=false&curInstr=1&heapPrimitives=nevernest&mode=display&origin=opt-frontend.js&py=java&rawInputLstJSON=%5B%5D&textReferences=false" target="_blank" style="text-decoration:underline">visualization</a>
-
-The Java |visualization| below shows how a song can be divided up into methods. Click on the next button below the code to step through the code. Execution in Java always begins in the ``main`` method in the current class. Then, the flow of control skips from method to method as they are called.  The Song's print method calls the chorus() and animal() methods to help it print out the whole song.
+The Java `visualization <http://www.pythontutor.com/java.html#code=public%20class%20Song%20%7B%0A%20%20%0A%20%20%20%20public%20void%20print%28%29%20%7B%0A%20%20%20%20%20%20%20%20System.out.println%28%22Old%20MacDonald%20had%20a%20farm%22%29%3B%0A%20%20%20%20%20%20%20%20chorus%28%29%3B%0A%20%20%20%20%20%20%20%20System.out.print%28%22And%20on%20that%20farm%20he%20had%20a%20%22%29%3B%0A%20%20%20%20%20%20%20%20animal%28%29%3B%0A%20%20%20%20%20%20%20%20chorus%28%29%3B%0A%20%20%20%20%7D%0A%20%20%20%20public%20void%20chorus%28%29%0A%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20System.out.println%28%22E-I-E-I-O%22%29%3B%0A%20%20%20%20%7D%0A%20%20%20%20%0A%20%20%20%20public%20void%20animal%28%29%20%7B%0A%20%20%20%20%20%20%20System.out.println%28%22duck%22%29%3B%0A%20%20%20%20%7D%0A%20%20%20%20public%20static%20void%20main%28String%5B%5D%20args%29%20%7B%0A%20%20%20%20%20%20%20Song%20s%20%3D%20new%20Song%28%29%3B%0A%20%20%20%20%20%20%20s.print%28%29%3B%0A%20%20%20%20%7D%0A%7D&cumulative=false&curInstr=1&heapPrimitives=nevernest&mode=display&origin=opt-frontend.js&py=java&rawInputLstJSON=%5B%5D&textReferences=false>`_ below shows how a song can be divided up into methods. Click on the next button below the code to step through the code. Execution in Java always begins in the ``main`` method in the current class. Then, the flow of control skips from method to method as they are called.  The Song's print method calls the chorus() and animal() methods to help it print out the whole song.
 
 When you call the chorus() method, it skips to the chorus code, executes and prints out the chorus, and then returns back to the method that called it.
 
@@ -356,11 +350,8 @@ Methods inside the same class can call each other using just ``methodName()``, b
         }
     }
 
-.. |visualization2| raw:: html
 
-   <a href="http://www.pythontutor.com/visualize.html#code=public%20class%20Song%20%7B%0A%20%20%0A%20%20%20%20%20%20%20%20public%20void%20print%28%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20System.out.print%28%22I%20like%20to%20%22%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20eat%28%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20eat%28%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20eat%28%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20fruit%28%29%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20public%20void%20fruit%28%29%0A%20%20%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20System.out.println%28%22apples%20and%20bananas!%22%29%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%0A%20%20%20%20%20%20%20%20public%20void%20eat%28%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20System.out.print%28%22eat%20%22%29%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20public%20static%20void%20main%28String%5B%5D%20args%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20Song%20s%20%3D%20new%20Song%28%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20s.print%28%29%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%7D&cumulative=false&curInstr=1&heapPrimitives=nevernest&mode=display&origin=opt-frontend.js&py=java&rawInputLstJSON=%5B%5D&textReferences=false" target="_blank" style="text-decoration:underline">visualization</a>
-
-Try this |visualization2| to see this code in action.
+Try this `visualization <http://www.pythontutor.com/visualize.html#code=public%20class%20Song%20%7B%0A%20%20%0A%20%20%20%20%20%20%20%20public%20void%20print%28%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20System.out.print%28%22I%20like%20to%20%22%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20eat%28%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20eat%28%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20eat%28%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20fruit%28%29%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20public%20void%20fruit%28%29%0A%20%20%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20System.out.println%28%22apples%20and%20bananas!%22%29%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%0A%20%20%20%20%20%20%20%20public%20void%20eat%28%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20System.out.print%28%22eat%20%22%29%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20public%20static%20void%20main%28String%5B%5D%20args%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20Song%20s%20%3D%20new%20Song%28%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20s.print%28%29%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%7D&cumulative=false&curInstr=1&heapPrimitives=nevernest&mode=display&origin=opt-frontend.js&py=java&rawInputLstJSON=%5B%5D&textReferences=false>`_ to see this code in action.
 
 
 .. note::
@@ -375,7 +366,7 @@ Before you call a method from ``main`` or from outside of the current class, you
 |Groupwork| Programming Challenge : Draw a Letter
 -------------------------------------------------
 
-Working in pairs, use the area below (or the |repl link|) to use a turtle to draw a simple block-style letter or number that uses just straight lines (no curves or diagonals). It could be one of your initials or a number from today's date.
+Working in pairs, use the area below (or the `replit.com link <https://replit.com/@BerylHoffman/Java-Swing-Turtle#Main.java>`_) to use a turtle to draw a simple block-style letter or number that uses just straight lines (no curves or diagonals). It could be one of your initials or a number from today's date.
 
 It may help to act out the code pretending you are the turtle. Remember that which way you turn depends on which direction you are facing, and the turtle begins facing north (towards the top of the page).
 
@@ -388,9 +379,6 @@ Here are some simple turtle methods that you can use:
 - ``penUp()``
 - ``penDown()``
 
-.. |repl link| raw:: html
-
-   <a href="https://replit.com/@BerylHoffman/Java-Swing-Turtle#Main.java" target="_blank">replit.com link</a>
 
 You may notice that it is challenging to have your turtle draw with these simple methods. In the next lesson, we will use more complex ``Turtle`` methods where you can indicate how many steps to take or what angle to turn that will make drawing a lot easier!
 

--- a/_sources/Unit1-Using-Objects-and-Methods/topic-1-15-strings.rst
+++ b/_sources/Unit1-Using-Objects-and-Methods/topic-1-15-strings.rst
@@ -392,17 +392,9 @@ What if you wanted to print out a double quote " character? Since the double quo
 
 Have you ever played MAD LIBS? In this game, you first choose a bunch of words without looking at the story and then those words are filled into the story to make it sound very wacky! Fill in the variables below with Strings for each word, and then run to see the wacky story.
 
-.. |repl| raw:: html
-
-   <a href="https://replit.com" target="_blank">replit.com</a>
 
 
-.. |Scanner| raw:: html
-
-   <a href="https://www.w3schools.com/java/java_user_input.asp" target="_blank">Scanner class</a>
-
-
-Then, working in pairs, come up with another silly story that uses at least 5 new String variables. When you're done, try another team's mad libs code. Your teacher may ask you to create this program in a Java IDE like |repl| so that you can use input to read in the words (see input examples using the |Scanner|).
+Then, working in pairs, come up with another silly story that uses at least 5 new String variables. When you're done, try another team's mad libs code. Your teacher may ask you to create this program in a Java IDE like `replit.com <https://replit.com>`_ so that you can use input to read in the words (see input examples using the `Scanner class <https://www.w3schools.com/java/java_user_input.asp>`_).
 
 .. activecode:: challenge2-6-MadLibs
    :language: java

--- a/_sources/Unit1-Using-Objects-and-Methods/topic-1-3-expressions.rst
+++ b/_sources/Unit1-Using-Objects-and-Methods/topic-1-3-expressions.rst
@@ -28,11 +28,8 @@ Assignment Statements
 
 Instead of saying equals for the = in an assignment statement, say "gets" or "is assigned" to remember that the variable gets or is assigned the value on the right. In the figure above score is assigned the value of the expression 10 times points (which is another variable) plus 5.
 
-.. |video| raw:: html
 
-   <a href="https://www.youtube.com/watch?v=MZwIgM__5C8&ab_channel=colleenlewis" target="_blank">video</a>
-
-The following |video| by Dr. Colleen Lewis shows how variables can change values in memory using assignment statements.
+The following `video <https://www.youtube.com/watch?v=MZwIgM__5C8&ab_channel=colleenlewis>`_ by Dr. Colleen Lewis shows how variables can change values in memory using assignment statements.
 
 .. youtube:: MZwIgM__5C8
     :width: 700px
@@ -44,11 +41,8 @@ As we saw in the video, we can set one variable's value to a *copy* of the value
 
 
 
-.. |Java visualizer| raw:: html
 
-   <a href="http://www.pythontutor.com/visualize.html#code=public+class+Test2%0A%7B%0A+++public+static+void+main(String%5B%5D+args%29%0A+++%7B%0A+++++int+x+%3D+3%3B%0A+++++int+y+%3D+2%3B%0A+++++System.out.println(x%29%3B%0A+++++System.out.println(y%29%3B%0A+++++x+%3D+y%3B%0A+++++System.out.println(x%29%3B%0A+++++System.out.println(y%29%3B%0A+++++y+%3D+5%3B%0A+++++System.out.println(x%29%3B%0A+++++System.out.println(y%29%3B%0A+++%7D%0A%7D&mode=display&origin=opt-frontend.js&cumulative=false&heapPrimitives=false&textReferences=false&py=java&rawInputLstJSON=%5B%5D&curInstr=0" target="_blank"  style="text-decoration:underline">Java visualizer</a>
-
-Let's step through the following code in the |Java visualizer| to see the values in memory. Click on the Next button at the bottom of the code to see how the values of the variables change. You can run the visualizer on any Active Code in this e-book by just clicking on the Code Lens button at the top of each Active Code.
+Let's step through the following code in the `Java visualizer <http://www.pythontutor.com/visualize.html#code=public+class+Test2%0A%7B%0A+++public+static+void+main(String%5B%5D+args%29%0A+++%7B%0A+++++int+x+%3D+3%3B%0A+++++int+y+%3D+2%3B%0A+++++System.out.println(x%29%3B%0A+++++System.out.println(y%29%3B%0A+++++x+%3D+y%3B%0A+++++System.out.println(x%29%3B%0A+++++System.out.println(y%29%3B%0A+++++y+%3D+5%3B%0A+++++System.out.println(x%29%3B%0A+++++System.out.println(y%29%3B%0A+++%7D%0A%7D&mode=display&origin=opt-frontend.js&cumulative=false&heapPrimitives=false&textReferences=false&py=java&rawInputLstJSON=%5B%5D&curInstr=0>`_ to see the values in memory. Click on the Next button at the bottom of the code to see how the values of the variables change. You can run the visualizer on any Active Code in this e-book by just clicking on the Code Lens button at the top of each Active Code.
 
 
 .. codelens:: asgn_viz1
@@ -76,9 +70,6 @@ Let's step through the following code in the |Java visualizer| to see the values
 
 |Exercise| **Check your understanding**
 
-.. |Java visualizer2| raw:: html
-
-   <a href="http://www.pythontutor.com/visualize.html#code=public+class+Test2%0A%7B%0A+++public+static+void+main(String%5B%5D+args%29%0A+++%7B%0A+++++int+x+%3D+0%3B%0A+++++int+y+%3D+1%3B%0A+++++int+z+%3D+2%3B%0A+++++x+%3D+y%3B%0A+++++y+%3D+y+*+2%3B%0A+++++z+%3D+3%3B%0A+++++System.out.println(x%29%3B%0A+++++System.out.println(y%29%3B%0A+++++System.out.println(z%29%3B%0A+++%7D%0A%7D&mode=display&origin=opt-frontend.js&cumulative=false&heapPrimitives=false&textReferences=false&py=java&rawInputLstJSON=%5B%5D&curInstr=0" target="_blank"  style="text-decoration:underline">Java visualizer</a>
 
 .. mchoice:: q2_1
    :practice: T
@@ -92,7 +83,7 @@ Let's step through the following code in the |Java visualizer| to see the values
    :feedback_c: Remember that the equal sign doesn't mean that the two sides are equal.  It sets the value for the variable on the left to the value from evaluating the right side.
    :feedback_d: Remember that the equal sign doesn't mean that the two sides are equal.  It sets the value for the variable on the left to the value from evaluating the right side.
 
-   What are the values of x, y, and z after the following code executes?  You can step through this code by clicking on this |Java visualizer2| link.
+   What are the values of x, y, and z after the following code executes?  You can step through this code by clicking on this `Java visualizer <http://www.pythontutor.com/visualize.html#code=public+class+Test2%0A%7B%0A+++public+static+void+main(String%5B%5D+args%29%0A+++%7B%0A+++++int+x+%3D+0%3B%0A+++++int+y+%3D+1%3B%0A+++++int+z+%3D+2%3B%0A+++++x+%3D+y%3B%0A+++++y+%3D+y+*+2%3B%0A+++++z+%3D+3%3B%0A+++++System.out.println(x%29%3B%0A+++++System.out.println(y%29%3B%0A+++++System.out.println(z%29%3B%0A+++%7D%0A%7D&mode=display&origin=opt-frontend.js&cumulative=false&heapPrimitives=false&textReferences=false&py=java&rawInputLstJSON=%5B%5D&curInstr=0>`_ link.
 
    .. code-block:: java
 
@@ -180,17 +171,9 @@ score variable is set to the previous value of score plus 1.
 Input with Variables
 --------------------
 
-.. |JavaIOExample| raw:: html
-
-   <a href="https://firewalledreplit.com/@BerylHoffman/JavaIOExample" target="_blank">Java Scanner Input Repl</a>
 
 
-.. |JavaIOConsole| raw:: html
-
-   <a href="https://firewalledreplit.com/@BerylHoffman/JavaIOConsole" target="_blank">Java Console Input Repl</a>
-
-
-Variables are a powerful abstraction in programming because the same algorithm can be used with different input values saved in variables.  The code below (|JavaIOExample| using the ``Scanner`` class or |JavaIOConsole| using the ``Console`` class) will say hello to anyone who types in their name for different name values. Click on run and then type in your name. Then, try run again and type in a friend's name. The code works for any name: behold, the power of variables!
+Variables are a powerful abstraction in programming because the same algorithm can be used with different input values saved in variables.  The code below (`Java Scanner Input Repl <https://firewalledreplit.com/@BerylHoffman/JavaIOExample>`_ using the ``Scanner`` class or `Java Console Input Repl <https://firewalledreplit.com/@BerylHoffman/JavaIOConsole>`_ using the ``Console`` class) will say hello to anyone who types in their name for different name values. Click on run and then type in your name. Then, try run again and type in a friend's name. The code works for any name: behold, the power of variables!
 
 .. raw:: html
 
@@ -373,11 +356,8 @@ of truncating integer division, only matters when negative operands are involved
 and the signs of the operands differ. With positive operands, remainder and mod give the same results. 
 Java does have a method ``Math.floorMod`` in the ``Math`` class if you need to use modulo instead of remainder, but ``%`` is all you need in the AP exam.
 
-.. |video2| raw:: html
 
-   <a href="https://www.youtube.com/watch?v=jp-T9lFISlI&ab_channel=colleenlewis" target="_blank">video</a>
-
-Here’s the |video2|.
+Here’s the `video <https://www.youtube.com/watch?v=jp-T9lFISlI&ab_channel=colleenlewis>`_.
 
 .. youtube:: jp-T9lFISlI
     :width: 700px
@@ -599,20 +579,10 @@ In this programming challenge, you will calculate your age, and your pet's age f
    }
 
 
-.. |repl| raw:: html
-
-   <a href="https://replit.com" target="_blank">replit.com</a>
 
 
-.. |Scanner| raw:: html
 
-   <a href="https://www.w3schools.com/java/java_user_input.asp" target="_blank">Scanner class</a>
-
-.. |repl template| raw:: html
-
-   <a href="https://firewalledreplit.com/@BerylHoffman/Challenge1-4-Dog-Years-Template" target="_blank">repl template</a>
-
-Your teacher may suggest that you use a Java IDE like |repl| for this challenge so that you can use input to get these values using the |Scanner|. Here is a |repl template| that you can use to get started if you want to try the challenge with input.
+Your teacher may suggest that you use a Java IDE like `replit.com <https://replit.com>`_ for this challenge so that you can use input to get these values using the `Scanner class <https://www.w3schools.com/java/java_user_input.asp>`_. Here is a `repl template <https://firewalledreplit.com/@BerylHoffman/Challenge1-4-Dog-Years-Template>`_ that you can use to get started if you want to try the challenge with input.
 
 Summary
 -------------------

--- a/_sources/Unit1-Using-Objects-and-Methods/topic-1-4-assignment.rst
+++ b/_sources/Unit1-Using-Objects-and-Methods/topic-1-4-assignment.rst
@@ -28,11 +28,8 @@ Assignment Statements
 
 Instead of saying equals for the = in an assignment statement, say "gets" or "is assigned" to remember that the variable gets or is assigned the value on the right. In the figure above score is assigned the value of the expression 10 times points (which is another variable) plus 5.
 
-.. |video| raw:: html
 
-   <a href="https://www.youtube.com/watch?v=MZwIgM__5C8&ab_channel=colleenlewis" target="_blank">video</a>
-
-The following |video| by Dr. Colleen Lewis shows how variables can change values in memory using assignment statements.
+The following `video <https://www.youtube.com/watch?v=MZwIgM__5C8&ab_channel=colleenlewis>`_ by Dr. Colleen Lewis shows how variables can change values in memory using assignment statements.
 
 .. youtube:: MZwIgM__5C8
     :width: 700px
@@ -44,11 +41,8 @@ As we saw in the video, we can set one variable's value to a *copy* of the value
 
 
 
-.. |Java visualizer| raw:: html
 
-   <a href="http://www.pythontutor.com/visualize.html#code=public+class+Test2%0A%7B%0A+++public+static+void+main(String%5B%5D+args%29%0A+++%7B%0A+++++int+x+%3D+3%3B%0A+++++int+y+%3D+2%3B%0A+++++System.out.println(x%29%3B%0A+++++System.out.println(y%29%3B%0A+++++x+%3D+y%3B%0A+++++System.out.println(x%29%3B%0A+++++System.out.println(y%29%3B%0A+++++y+%3D+5%3B%0A+++++System.out.println(x%29%3B%0A+++++System.out.println(y%29%3B%0A+++%7D%0A%7D&mode=display&origin=opt-frontend.js&cumulative=false&heapPrimitives=false&textReferences=false&py=java&rawInputLstJSON=%5B%5D&curInstr=0" target="_blank"  style="text-decoration:underline">Java visualizer</a>
-
-Let's step through the following code in the |Java visualizer| to see the values in memory. Click on the Next button at the bottom of the code to see how the values of the variables change. You can run the visualizer on any Active Code in this e-book by just clicking on the Code Lens button at the top of each Active Code.
+Let's step through the following code in the `Java visualizer <http://www.pythontutor.com/visualize.html#code=public+class+Test2%0A%7B%0A+++public+static+void+main(String%5B%5D+args%29%0A+++%7B%0A+++++int+x+%3D+3%3B%0A+++++int+y+%3D+2%3B%0A+++++System.out.println(x%29%3B%0A+++++System.out.println(y%29%3B%0A+++++x+%3D+y%3B%0A+++++System.out.println(x%29%3B%0A+++++System.out.println(y%29%3B%0A+++++y+%3D+5%3B%0A+++++System.out.println(x%29%3B%0A+++++System.out.println(y%29%3B%0A+++%7D%0A%7D&mode=display&origin=opt-frontend.js&cumulative=false&heapPrimitives=false&textReferences=false&py=java&rawInputLstJSON=%5B%5D&curInstr=0>`_ to see the values in memory. Click on the Next button at the bottom of the code to see how the values of the variables change. You can run the visualizer on any Active Code in this e-book by just clicking on the Code Lens button at the top of each Active Code.
 
 
 .. codelens:: asgn_viz1
@@ -76,9 +70,6 @@ Let's step through the following code in the |Java visualizer| to see the values
 
 |Exercise| **Check your understanding**
 
-.. |Java visualizer2| raw:: html
-
-   <a href="http://www.pythontutor.com/visualize.html#code=public+class+Test2%0A%7B%0A+++public+static+void+main(String%5B%5D+args%29%0A+++%7B%0A+++++int+x+%3D+0%3B%0A+++++int+y+%3D+1%3B%0A+++++int+z+%3D+2%3B%0A+++++x+%3D+y%3B%0A+++++y+%3D+y+*+2%3B%0A+++++z+%3D+3%3B%0A+++++System.out.println(x%29%3B%0A+++++System.out.println(y%29%3B%0A+++++System.out.println(z%29%3B%0A+++%7D%0A%7D&mode=display&origin=opt-frontend.js&cumulative=false&heapPrimitives=false&textReferences=false&py=java&rawInputLstJSON=%5B%5D&curInstr=0" target="_blank"  style="text-decoration:underline">Java visualizer</a>
 
 .. mchoice:: q2_1
    :practice: T
@@ -92,7 +83,7 @@ Let's step through the following code in the |Java visualizer| to see the values
    :feedback_c: Remember that the equal sign doesn't mean that the two sides are equal.  It sets the value for the variable on the left to the value from evaluating the right side.
    :feedback_d: Remember that the equal sign doesn't mean that the two sides are equal.  It sets the value for the variable on the left to the value from evaluating the right side.
 
-   What are the values of x, y, and z after the following code executes?  You can step through this code by clicking on this |Java visualizer2| link.
+   What are the values of x, y, and z after the following code executes?  You can step through this code by clicking on this `Java visualizer <http://www.pythontutor.com/visualize.html#code=public+class+Test2%0A%7B%0A+++public+static+void+main(String%5B%5D+args%29%0A+++%7B%0A+++++int+x+%3D+0%3B%0A+++++int+y+%3D+1%3B%0A+++++int+z+%3D+2%3B%0A+++++x+%3D+y%3B%0A+++++y+%3D+y+*+2%3B%0A+++++z+%3D+3%3B%0A+++++System.out.println(x%29%3B%0A+++++System.out.println(y%29%3B%0A+++++System.out.println(z%29%3B%0A+++%7D%0A%7D&mode=display&origin=opt-frontend.js&cumulative=false&heapPrimitives=false&textReferences=false&py=java&rawInputLstJSON=%5B%5D&curInstr=0>`_ link.
 
    .. code-block:: java
 
@@ -180,17 +171,9 @@ score variable is set to the previous value of score plus 1.
 Input with Variables
 --------------------
 
-.. |JavaIOExample| raw:: html
-
-   <a href="https://firewalledreplit.com/@BerylHoffman/JavaIOExample" target="_blank">Java Scanner Input Repl</a>
 
 
-.. |JavaIOConsole| raw:: html
-
-   <a href="https://firewalledreplit.com/@BerylHoffman/JavaIOConsole" target="_blank">Java Console Input Repl</a>
-
-
-Variables are a powerful abstraction in programming because the same algorithm can be used with different input values saved in variables.  The code below (|JavaIOExample| using the ``Scanner`` class or |JavaIOConsole| using the ``Console`` class) will say hello to anyone who types in their name for different name values. Click on run and then type in your name. Then, try run again and type in a friend's name. The code works for any name: behold, the power of variables!
+Variables are a powerful abstraction in programming because the same algorithm can be used with different input values saved in variables.  The code below (`Java Scanner Input Repl <https://firewalledreplit.com/@BerylHoffman/JavaIOExample>`_ using the ``Scanner`` class or `Java Console Input Repl <https://firewalledreplit.com/@BerylHoffman/JavaIOConsole>`_ using the ``Console`` class) will say hello to anyone who types in their name for different name values. Click on run and then type in your name. Then, try run again and type in a friend's name. The code works for any name: behold, the power of variables!
 
 .. raw:: html
 
@@ -373,11 +356,8 @@ of truncating integer division, only matters when negative operands are involved
 and the signs of the operands differ. With positive operands, remainder and mod give the same results. 
 Java does have a method ``Math.floorMod`` in the ``Math`` class if you need to use modulo instead of remainder, but ``%`` is all you need in the AP exam.
 
-.. |video2| raw:: html
 
-   <a href="https://www.youtube.com/watch?v=jp-T9lFISlI&ab_channel=colleenlewis" target="_blank">video</a>
-
-Here’s the |video2|.
+Here’s the `video <https://www.youtube.com/watch?v=jp-T9lFISlI&ab_channel=colleenlewis>`_.
 
 .. youtube:: jp-T9lFISlI
     :width: 700px
@@ -599,20 +579,10 @@ In this programming challenge, you will calculate your age, and your pet's age f
    }
 
 
-.. |repl| raw:: html
-
-   <a href="https://replit.com" target="_blank">replit.com</a>
 
 
-.. |Scanner| raw:: html
 
-   <a href="https://www.w3schools.com/java/java_user_input.asp" target="_blank">Scanner class</a>
-
-.. |repl template| raw:: html
-
-   <a href="https://firewalledreplit.com/@BerylHoffman/Challenge1-4-Dog-Years-Template" target="_blank">repl template</a>
-
-Your teacher may suggest that you use a Java IDE like |repl| for this challenge so that you can use input to get these values using the |Scanner|. Here is a |repl template| that you can use to get started if you want to try the challenge with input.
+Your teacher may suggest that you use a Java IDE like `replit.com <https://replit.com>`_ for this challenge so that you can use input to get these values using the `Scanner class <https://www.w3schools.com/java/java_user_input.asp>`_. Here is a `repl template <https://firewalledreplit.com/@BerylHoffman/Challenge1-4-Dog-Years-Template>`_ that you can use to get started if you want to try the challenge with input.
 
 Summary
 -------------------

--- a/_sources/Unit1-Using-Objects-and-Methods/topic-1-5-casting.rst
+++ b/_sources/Unit1-Using-Objects-and-Methods/topic-1-5-casting.rst
@@ -570,37 +570,15 @@ This would be a good project to work together in pairs, and switch drivers (who 
        }
    }
 
-.. |repl| raw:: html
-
-   <a href="https://replit.com" target="_blank">replit</a>
 
 
-.. |Scanner| raw:: html
 
-   <a href="https://www.w3schools.com/java/java_user_input.asp" target="_blank">Scanner class</a>
-
-.. |repl template| raw:: html
-
-   <a href="https://firewalledreplit.com/@BerylHoffman/Challenge1-6-Average-Template#Main.java" target="_blank">repl template</a>
-
-Your teacher may suggest that you use a Java IDE like |repl| for this challenge so that you can use input to get these values using the |Scanner|. Here is a |repl template| that you can use to get started if you want to try the challenge with input.
+Your teacher may suggest that you use a Java IDE like `replit <https://replit.com>`_ for this challenge so that you can use input to get these values using the `Scanner class <https://www.w3schools.com/java/java_user_input.asp>`_. Here is a `repl template <https://firewalledreplit.com/@BerylHoffman/Challenge1-6-Average-Template#Main.java>`_ that you can use to get started if you want to try the challenge with input.
 
 
-.. |Unicode| raw:: html
 
-   <a href="https://en.wikipedia.org/wiki/List_of_Unicode_characters" target="_blank">Unicode</a>
 
-.. |Chinese character| raw:: html
 
-   <a href="https://unicodelookup.com/#cjk/1" target="_blank">Chinese character</a>
-
-.. |Unicode Lookup| raw:: html
-
-   <a href="https://unicodelookup.com/" target="_blank">Unicode Lookup</a>
-
-.. |emoji| raw:: html
-
-   <a href="http://unicode.org/emoji/charts/full-emoji-list.html" target="_blank">emoji</a>
 
 Bonus Challenge : Unicode
 -------------------------------------
@@ -634,8 +612,8 @@ not on more recently added codepoints including, critically those for Emoji. �
 So better to use ``Character.toString`` and ignore ``char``.)
 
 Try the following program which prints out an English “A”, a 
-|Chinese character|, and an |emoji|. Then look up other characters at this 
-|Unicode Lookup| site and change the code to print them out. (Use the Dec column in site
+`Chinese character <https://unicodelookup.com/#cjk/1>`_, and an `emoji <http://unicode.org/emoji/charts/full-emoji-list.html>`_. Then look up other characters at this 
+`Unicode Lookup <https://unicodelookup.com/>`_ site and change the code to print them out. (Use the Dec column in site
 to get the decimal number.) Can you print out letters from 3 different
 languages?
 

--- a/_sources/Unit1-Using-Objects-and-Methods/topic-1-6-compound-operators.rst
+++ b/_sources/Unit1-Using-Objects-and-Methods/topic-1-6-compound-operators.rst
@@ -226,13 +226,8 @@ Trace through the following code:
 
    Write your trace table for x, y, and z here showing their results after each line of code.
 
-.. |Operators Maze game| raw:: html
 
-   <a href="https://docs.google.com/document/d/1ZjA8oKeo8FYx2nXX4OOq5lUihopIQQ_HY-eoE5yZkk8/edit?usp=sharing" target="_blank" style="text-decoration:underline">Operators Maze game</a>
-
-
-
-After doing this challenge, play the |Operators Maze game|. See if you and your
+After doing this challenge, play the `Operators Maze game <https://docs.google.com/document/d/1ZjA8oKeo8FYx2nXX4OOq5lUihopIQQ_HY-eoE5yZkk8/edit?usp=sharing>`_. See if you and your
 partner can get the highest score!
 
 Summary

--- a/_sources/Unit1-Using-Objects-and-Methods/topic-1-8-comments.rst
+++ b/_sources/Unit1-Using-Objects-and-Methods/topic-1-8-comments.rst
@@ -20,21 +20,12 @@ There are 3 types of comments in Java:
 2. ``/*`` Multiline comment ``*/``
 3. ``/**`` Documentation comment ``*/``
 
-.. |Java JDK| raw:: html
 
-   <a href="https://www.oracle.com/technetwork/java/javase/downloads/index.html" target="_blank">Java JDK</a>
 
-.. |javadoc| raw:: html
-
-   <a href="https://www.tutorialspoint.com/java/java_documentation.htm" target="_blank">javadoc</a>
-
-.. |String class| raw:: html
-
-   <a href="http://docs.oracle.com/javase/7/docs/api/java/lang/String.html" target="_blank">String class</a>
 
 The special characters ``//`` are used to mark the rest of the line as a comment in many programming languages.  If the comment is going to be multiple lines, we use ``/*`` to start the comment and ``*/`` to end the comment.
 
-There is also a special version of the multi-line comment, ``/**``  ``*/``, called the documentation comment. Java has a cool tool called |javadoc| that comes with the |Java JDK| that will pull out all of these comments to make documentation of a class as a web page.  This tool generates the official Java documentation too, for example for the |String class|. Although you do not have to use this in the AP exam, it's a good idea to use the documentation comment in front of classes, methods, and instance variables in case you want to use this tool.
+There is also a special version of the multi-line comment, ``/**``  ``*/``, called the documentation comment. Java has a cool tool called `javadoc <https://www.tutorialspoint.com/java/java_documentation.htm>`_ that comes with the `Java JDK <https://www.oracle.com/technetwork/java/javase/downloads/index.html>`_ that will pull out all of these comments to make documentation of a class as a web page.  This tool generates the official Java documentation too, for example for the `String class <http://docs.oracle.com/javase/7/docs/api/java/lang/String.html>`_. Although you do not have to use this in the AP exam, it's a good idea to use the documentation comment in front of classes, methods, and instance variables in case you want to use this tool.
 
 |Exercise| **Check your understanding**
 
@@ -104,15 +95,9 @@ Here is an example of preconditions, postconditions, and @param in the Turtle co
 
 Try to break the preconditions of the Turtle constructor below. Does the Turtle constructor behave properly if you break the preconditions that x and y are between 0 and 300. Try giving the Turtle constructor  x and y values out of these ranges. What happens? Does the method give good results? Does it give any warnings? What about the t.forward() method? Does it have any preconditions that you can break?
 
-.. |github| raw:: html
 
-   <a href="https://github.com/bhoffman0/APCSA-2019/tree/master/_sources/Unit2-Using-Objects/TurtleJavaSwingCode.zip" target="_blank" style="text-decoration:underline">here</a>
 
-.. |repl link| raw:: html
-
-   <a href="https://replit.com/@BerylHoffman/Java-Swing-Turtle" target="_blank" style="text-decoration:underline">replit.com link</a>
-
-(If the code below does not work for you, you can copy the code into  this |repl link| (refresh page after forking and if it gets stuck) or download the files |github| to use in your own IDE.)
+(If the code below does not work for you, you can copy the code into  this `replit.com link <https://replit.com/@BerylHoffman/Java-Swing-Turtle>`_ (refresh page after forking and if it gets stuck) or download the files `here <https://github.com/bhoffman0/APCSA-2019/tree/master/_sources/Unit2-Using-Objects/TurtleJavaSwingCode.zip>`_ to use in your own IDE.)
 
 .. activecode:: turtle-preconditions
     :language: java
@@ -323,11 +308,7 @@ There are many different models for software development. The **waterfall model*
 
     Figure 2: Waterfall vs Agile Models
 
-One very popular type of agile development is called **Scrum**. The following short |video| describes software development  with Scrum.
-
-.. |video| raw:: html
-
-   <a href="https://www.youtube.com/watch?v=TRcReyRYIMg" target="_blank">video</a>
+One very popular type of agile development is called **Scrum**. The following short `video <https://www.youtube.com/watch?v=TRcReyRYIMg>`_ describes software development  with Scrum.
 
 
 .. youtube:: TRcReyRYIMg
@@ -337,21 +318,15 @@ One very popular type of agile development is called **Scrum**. The following sh
 
 |Groupwork| Group Exercise
 
-.. |pogil game| raw:: html
 
-   <a href="https://www.agilesparks.com/blog/wake-up-in-the-morning-game/" target="_blank">Wake Up In the Morning Game</a>
-
-Try the |pogil game| in groups to practice the iterative and incremental agile development process.
+Try the `Wake Up In the Morning Game <https://www.agilesparks.com/blog/wake-up-in-the-morning-game/>`_ in groups to practice the iterative and incremental agile development process.
 
 
 |Groupwork| Programming Challenge : Comments and Conditions
 -----------------------------------------------------------
 
-.. |Creately.com| raw:: html
 
-   <a href="https://creately.com" target="_blank">Creately.com</a>
-
-Working in pairs or groups, come up with 4 steps that a user must do to purchase a product, for example a book on Java, in an online store, and list the preconditions and postconditions for each step. You could pretend to buy something online to come up with the steps. (You could use an online drawing tool like |Creately.com| (choose Use-Case Diagrams) to draw a Use-Case diagram for the Online Store System, but it is not required). Don't forget to list  the preconditions and postconditions for each step.  You can type in your answer below.
+Working in pairs or groups, come up with 4 steps that a user must do to purchase a product, for example a book on Java, in an online store, and list the preconditions and postconditions for each step. You could pretend to buy something online to come up with the steps. (You could use an online drawing tool like `Creately.com <https://creately.com>`_ (choose Use-Case Diagrams) to draw a Use-Case diagram for the Online Store System, but it is not required). Don't forget to list  the preconditions and postconditions for each step.  You can type in your answer below.
 
 .. shortanswer:: challenge-5-3-use-case-preconditions
 

--- a/_sources/Unit1-Using-Objects-and-Methods/topic-2-4-methods-with-params.rst
+++ b/_sources/Unit1-Using-Objects-and-Methods/topic-2-4-methods-with-params.rst
@@ -10,10 +10,6 @@
     single: argument
 
 
-.. |github| raw:: html
-
-   <a href="https://github.com/bhoffman0/APCSA-2019/tree/master/_sources/Unit2-Using-Objects/TurtleJavaSwingCode.zip" target="_blank" style="text-decoration:underline">here</a>
-
 
 .. |runbutton| image:: Figures/run-button.png
     :height: 30px
@@ -107,13 +103,7 @@ Here is the Turtle class diagram again that shows some of the variables and meth
 
     Figure 1: Turtle Class Diagram
 
-.. |Color| raw:: html
 
-   <a href= "https://docs.oracle.com/javase/7/docs/api/java/awt/Color.html" target="_blank">Color</a>
-
-.. |javadoc (documentation) file| raw:: html
-
-   <a href="https://www2.cs.uic.edu/~i101/doc/SimpleTurtle.html" target="_blank">javadoc (documentation) file</a>
 
 Try some of the methods above in the turtle code below. You can see all the methods that are inherited in Turtle in this |javadoc (documentation) file|.
 
@@ -124,7 +114,7 @@ different **method signature**, where it requires a different number or type of 
 
 |CodingEx| **Coding Exercise**
 
-(If the code below does not work in your browser, you can also use the Turtle code at this |repl link| (refresh page after forking and if it gets stuck) or download the files |github| to use in your own IDE.)
+(If the code below does not work in your browser, you can also use the Turtle code at this `replit.com link <https://replit.com/@BerylHoffman/Java-Swing-Turtle#Main.java>`_ (refresh page after forking and if it gets stuck) or download the files `here <https://github.com/bhoffman0/APCSA-2019/tree/master/_sources/Unit2-Using-Objects/TurtleJavaSwingCode.zip>`_ to use in your own IDE.)
 
 
 .. activecode:: TurtleTestMethods1
@@ -132,7 +122,7 @@ different **method signature**, where it requires a different number or type of 
     :autograde: unittest
     :datafile: turtleClasses.jar
 
-    1. Can you make yertle draw a square and change the pen color for each side of the square? Try something like: yertle.setColor(Color.red); This uses the |Color| class in Java which has some colors predefined like red, yellow, blue, magenta, cyan. You can also use more specific methods like setPenColor, setBodyColor, and setShellColor.
+    1. Can you make yertle draw a square and change the pen color for each side of the square? Try something like: yertle.setColor(Color.red); This uses the `Color <https://docs.oracle.com/javase/7/docs/api/java/awt/Color.html>`_ class in Java which has some colors predefined like red, yellow, blue, magenta, cyan. You can also use more specific methods like setPenColor, setBodyColor, and setShellColor.
     2. Can you draw a triangle? The turnRight() method always does 90 degree turns, but you'll need external angles of 120 degree for an equilateral triangle. Use the turn method which has a parameter for the angle of the turn in degrees. For example, turn(90) is the same as turnRight(). Try drawing a triangle with different colors.
     ~~~~
     import java.awt.*;
@@ -300,9 +290,6 @@ You will not write your own methods until Unit 5, but you should be able to trac
 Here is another version of the Old MacDonald Song with a more powerful abstraction. The method verse has 2 parameters for the animal and the noise it makes, so that it can be used for any animal.
 Use the Code Lens button or this |Java Visualizer| to step through the code.
 
-.. |Java visualizer| raw:: html
-
-   <a href="http://www.pythontutor.com/java.html#code=public%20class%20Song%20%0A%7B%0A%20%20%0A%20%20%20%20public%20void%20verse%28String%20animal,%20String%20noise%29%20%0A%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20System.out.println%28%22Old%20MacDonald%20had%20a%20farm%22%29%3B%0A%20%20%20%20%20%20%20%20chorus%28%29%3B%0A%20%20%20%20%20%20%20%20System.out.println%28%22And%20on%20that%20farm%20he%20had%20a%20%22%20%2B%20animal%29%3B%0A%20%20%20%20%20%20%20%20chorus%28%29%3B%0A%20%20%20%20%20%20%20%20System.out.println%28%22With%20a%20%22%20%2B%20noise%20%2B%20%22%20%22%20%2B%20noise%20%2B%20%22%20here,%22%29%3B%0A%20%20%20%20%20%20%20%20System.out.println%28%22And%20a%20%22%20%2B%20noise%20%2B%20%22%20%22%20%2B%20noise%20%2B%20%22%20there,%22%29%3B%0A%20%20%20%20%20%20%20%20System.out.println%28%22Old%20MacDonald%20had%20a%20farm%22%29%3B%0A%20%20%20%20%20%20%20%20chorus%28%29%3B%0A%20%20%20%20%7D%0A%20%20%20%20public%20void%20chorus%28%29%0A%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20System.out.println%28%22E-I-E-I-O%22%29%3B%0A%20%20%20%20%7D%0A%20%20%20%20%0A%20%20%20%20public%20static%20void%20main%28String%5B%5D%20args%29%20%0A%20%20%20%20%7B%0A%20%20%20%20%20%20%20Song%20s%20%3D%20new%20Song%28%29%3B%0A%20%20%20%20%20%20%20s.verse%28%22cow%22,%20%22moo%22%29%3B%0A%20%20%20%20%20%20%20s.verse%28%22duck%22,%22quack%22%29%3B%0A%20%20%20%20%7D%0A%7D&cumulative=false&curInstr=1&heapPrimitives=nevernest&mode=display&origin=opt-frontend.js&py=java&rawInputLstJSON=%5B%5D&textReferences=false" target="_blank" style="text-decoration:underline">Java visualizer</a>
 
 .. activecode:: SongFarm
     :language: java
@@ -448,11 +435,8 @@ Use the Code Lens button or this |Java Visualizer| to step through the code.
           }
       }
 
-.. |visualization| raw:: html
 
-   <a href="http://www.pythontutor.com/visualize.html#code=%20%20public%20class%20MethodTrace%20%0A%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20public%20void%20square%28int%20x%29%0A%20%20%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20System.out.print%28x*x%29%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20public%20void%20divide%28int%20x,%20int%20y%29%0A%20%20%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20System.out.println%28x/y%29%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20public%20static%20void%20main%28String%5B%5D%20args%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20MethodTrace%20traceObj%20%3D%20new%20MethodTrace%28%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20traceObj.square%285%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20System.out.print%28%22%20and%20%22%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20traceObj.divide%284,2%29%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%7D&cumulative=false&curInstr=18&heapPrimitives=nevernest&mode=display&origin=opt-frontend.js&py=java&rawInputLstJSON=%5B%5D&textReferences=false" target="_blank" style="text-decoration:underline">visualization</a>
-
-Try this |visualization| to see this code in action.
+Try this `visualization <http://www.pythontutor.com/visualize.html#code=%20%20public%20class%20MethodTrace%20%0A%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20public%20void%20square%28int%20x%29%0A%20%20%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20System.out.print%28x*x%29%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20public%20void%20divide%28int%20x,%20int%20y%29%0A%20%20%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20System.out.println%28x/y%29%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20public%20static%20void%20main%28String%5B%5D%20args%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20MethodTrace%20traceObj%20%3D%20new%20MethodTrace%28%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20traceObj.square%285%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20System.out.print%28%22%20and%20%22%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20traceObj.divide%284,2%29%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%7D&cumulative=false&curInstr=18&heapPrimitives=nevernest&mode=display&origin=opt-frontend.js&py=java&rawInputLstJSON=%5B%5D&textReferences=false>`_ to see this code in action.
 
 |Groupwork| Programming Challenge : Turtle House
 ------------------------------------------------
@@ -462,7 +446,7 @@ Try this |visualization| to see this code in action.
     :align: left
     :alt: simple house
 
-This creative challenge is fun to do collaboratively in pairs. Design a house and have the turtle draw it with different colors below (or with this |repl link|). Can you add windows and a door? Come up with your own house design as a team.
+This creative challenge is fun to do collaboratively in pairs. Design a house and have the turtle draw it with different colors below (or with this `replit.com link <https://replit.com/@BerylHoffman/Java-Swing-Turtle#Main.java>`_). Can you add windows and a door? Come up with your own house design as a team.
 
 To draw a window, you will need to call ``penUp`` to walk the turtle into position, for example:
 
@@ -473,10 +457,6 @@ To draw a window, you will need to call ``penUp`` to walk the turtle into positi
    builder.penDown();
 
 It may help to act out the code pretending you are the turtle. Remember that the angles you turn depend on which direction you are facing, and the turtle begins facing up.
-
-.. |repl link| raw:: html
-
-   <a href="https://replit.com/@BerylHoffman/Java-Swing-Turtle#Main.java" target="_blank">replit.com link</a>
 
 
 .. activecode:: challenge2-4-TurtleHouse

--- a/_sources/Unit1-Using-Objects-and-Methods/topic-2-5-methods-return.rst
+++ b/_sources/Unit1-Using-Objects-and-Methods/topic-2-5-methods-return.rst
@@ -15,13 +15,7 @@
     :align: top
     :alt: run button
 
-.. |repl link| raw:: html
 
-   <a href="https://replit.com/@BerylHoffman/Java-Swing-Turtle#Main.java" target="_blank" style="text-decoration:underline">replit.com link</a>
-
-.. |github| raw:: html
-
-   <a href="https://github.com/bhoffman0/APCSA-2019/tree/master/_sources/Unit2-Using-Objects/TurtleJavaSwingCode.zip" target="_blank" style="text-decoration:underline">here</a>
 
 ..  |Time45|
 
@@ -106,8 +100,8 @@ Here are some examples of using getters on the ``Turtle`` object ``yertle``.
     it made? Try changing where it moves to make sure.
 
     (If the code below does not work in your browser, you can also copy in the
-    code below into the Turtle code at this |repl link| (refresh page after
-    forking and if it gets stuck) or download the files |github| to use in your
+    code below into the Turtle code at this `replit.com link <https://replit.com/@BerylHoffman/Java-Swing-Turtle#Main.java>`_ (refresh page after
+    forking and if it gets stuck) or download the files `here <https://github.com/bhoffman0/APCSA-2019/tree/master/_sources/Unit2-Using-Objects/TurtleJavaSwingCode.zip>`_ to use in your
     own IDE.)
 
     ~~~~
@@ -379,17 +373,7 @@ of the method. The calling method must then do something useful with that value.
 
 |Exercise| **Check your understanding**
 
-.. |visualization1| raw:: html
 
-   <a href="https://pythontutor.com/visualize.html#code=public%20class%20Circle%0A%7B%0A%20%20%20%20private%20double%20radius%3B%0A%0A%20%20%20%20public%20Circle%28double%20r%29%0A%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20radius%20%3D%20r%3B%0A%20%20%20%20%7D%0A%0A%20%20%20%20public%20double%20getArea%28%29%0A%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20return%203.14159%20*%20radius%20*%20radius%3B%0A%20%20%20%20%7D%0A%0A%20%20%20%20public%20static%20void%20main%28String%5B%5D%20args%29%20%7B%0A%20%20%20%20%20%20%20%20Circle%20c%20%3D%20new%20Circle%2810%29%3B%0A%20%20%20%20%20%20%20%20System.out.println%28c.getArea%28%29%29%3B%0A%20%20%20%20%7D%0A%7D&cumulative=false&heapPrimitives=nevernest&mode=edit&origin=opt-frontend.js&py=java&rawInputLstJSON=%5B%5D&textReferences=false" target="_blank" style="text-decoration:underline">visualization</a>
-
-.. |visualization2| raw:: html
-
-   <a href="https://pythontutor.com/render.html#code=public%20class%20Rectangle%0A%7B%0A%20%20%20%20private%20int%20width%3B%0A%20%20%20%20private%20int%20height%3B%0A%0A%20%20%20%20public%20Rectangle%28int%20w,%20int%20h%29%0A%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20width%20%3D%20w%3B%0A%20%20%20%20%20%20%20%20height%20%3D%20h%3B%0A%20%20%20%20%7D%0A%0A%20%20%20%20public%20void%20resize%28%29%0A%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20width%20%2B%3D%205%3B%0A%20%20%20%20%7D%0A%0A%20%20%20%20public%20int%20getArea%28%29%0A%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20return%20width%20*%20height%3B%0A%20%20%20%20%7D%0A%0A%20%20%20%20public%20static%20void%20main%28String%5B%5D%20args%29%0A%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20Rectangle%20r%20%3D%20new%20Rectangle%2810,%2015%29%3B%0A%20%20%20%20%20%20%20%20r.resize%28%29%3B%0A%20%20%20%20%20%20%20%20System.out.println%28r.getArea%28%29%29%3B%0A%20%20%20%20%7D%0A%7D&cumulative=false&curInstr=20&heapPrimitives=nevernest&mode=display&origin=opt-frontend.js&py=java&rawInputLstJSON=%5B%5D&textReferences=false" target="_blank" style="text-decoration:underline">visualization</a>
-
-.. |visualization3| raw:: html
-
-   <a href="http://www.pythontutor.com/visualize.html#code=public%20class%20MethodTrace%20%0A%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20public%20int%20square%28int%20x%29%0A%20%20%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20x*x%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20public%20int%20divide%28int%20x,%20int%20y%29%0A%20%20%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20return%20x/y%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20public%20static%20void%20main%28String%5B%5D%20args%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20MethodTrace%20traceObj%20%3D%20new%20MethodTrace%28%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20System.out.println%28%20traceObj.square%282%29%20%2B%20traceObj.divide%286,2%29%20%29%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%7D&cumulative=false&curInstr=16&heapPrimitives=nevernest&mode=display&origin=opt-frontend.js&py=java&rawInputLstJSON=%5B%5D&textReferences=false" target="_blank" style="text-decoration:underline">visualization</a>
 
 
 .. mchoice:: traceCircleArea
@@ -432,7 +416,7 @@ of the method. The calling method must then do something useful with that value.
         Circle c = new Circle(10);
         System.out.println(c.getArea());
 
-   What is printed as a result of executing the code segment? (If you get stuck, try this |visualization1| to see this code in action.)
+   What is printed as a result of executing the code segment? (If you get stuck, try this `visualization <https://pythontutor.com/visualize.html#code=public%20class%20Circle%0A%7B%0A%20%20%20%20private%20double%20radius%3B%0A%0A%20%20%20%20public%20Circle%28double%20r%29%0A%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20radius%20%3D%20r%3B%0A%20%20%20%20%7D%0A%0A%20%20%20%20public%20double%20getArea%28%29%0A%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20return%203.14159%20*%20radius%20*%20radius%3B%0A%20%20%20%20%7D%0A%0A%20%20%20%20public%20static%20void%20main%28String%5B%5D%20args%29%20%7B%0A%20%20%20%20%20%20%20%20Circle%20c%20%3D%20new%20Circle%2810%29%3B%0A%20%20%20%20%20%20%20%20System.out.println%28c.getArea%28%29%29%3B%0A%20%20%20%20%7D%0A%7D&cumulative=false&heapPrimitives=nevernest&mode=edit&origin=opt-frontend.js&py=java&rawInputLstJSON=%5B%5D&textReferences=false>`_ to see this code in action.)
 
 
 .. mchoice:: traceRectangleArea
@@ -485,7 +469,7 @@ of the method. The calling method must then do something useful with that value.
         System.out.println(r.getArea());
 
 
-   What is printed as a result of executing the code segment? (If you get stuck, try this |visualization2| to see this code in action.)
+   What is printed as a result of executing the code segment? (If you get stuck, try this `visualization <https://pythontutor.com/render.html#code=public%20class%20Rectangle%0A%7B%0A%20%20%20%20private%20int%20width%3B%0A%20%20%20%20private%20int%20height%3B%0A%0A%20%20%20%20public%20Rectangle%28int%20w,%20int%20h%29%0A%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20width%20%3D%20w%3B%0A%20%20%20%20%20%20%20%20height%20%3D%20h%3B%0A%20%20%20%20%7D%0A%0A%20%20%20%20public%20void%20resize%28%29%0A%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20width%20%2B%3D%205%3B%0A%20%20%20%20%7D%0A%0A%20%20%20%20public%20int%20getArea%28%29%0A%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20return%20width%20*%20height%3B%0A%20%20%20%20%7D%0A%0A%20%20%20%20public%20static%20void%20main%28String%5B%5D%20args%29%0A%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20Rectangle%20r%20%3D%20new%20Rectangle%2810,%2015%29%3B%0A%20%20%20%20%20%20%20%20r.resize%28%29%3B%0A%20%20%20%20%20%20%20%20System.out.println%28r.getArea%28%29%29%3B%0A%20%20%20%20%7D%0A%7D&cumulative=false&curInstr=20&heapPrimitives=nevernest&mode=display&origin=opt-frontend.js&py=java&rawInputLstJSON=%5B%5D&textReferences=false>`_ to see this code in action.)
 
 
 .. mchoice:: traceReturnMethods
@@ -502,7 +486,7 @@ of the method. The calling method must then do something useful with that value.
    :feedback_d: Make sure you square(2) and add the results before printing it out.
    :feedback_e: Try the code in an active code window.
 
-   What does the following code print out? (If you get stuck, try this |visualization3| to see this code in action.)
+   What does the following code print out? (If you get stuck, try this `visualization <http://www.pythontutor.com/visualize.html#code=public%20class%20MethodTrace%20%0A%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20public%20int%20square%28int%20x%29%0A%20%20%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20x*x%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20public%20int%20divide%28int%20x,%20int%20y%29%0A%20%20%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20return%20x/y%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20public%20static%20void%20main%28String%5B%5D%20args%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20MethodTrace%20traceObj%20%3D%20new%20MethodTrace%28%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20System.out.println%28%20traceObj.square%282%29%20%2B%20traceObj.divide%286,2%29%20%29%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%7D&cumulative=false&curInstr=16&heapPrimitives=nevernest&mode=display&origin=opt-frontend.js&py=java&rawInputLstJSON=%5B%5D&textReferences=false>`_ to see this code in action.)
 
    .. code-block:: java
 
@@ -712,7 +696,7 @@ AP Practice
         water.lowerTemp();
         System.out.println(water.getTemp());
 
-    What is printed as a result of executing the code segment? (If you get stuck, try this |visualizationLiquid| to see this code in action.)
+    What is printed as a result of executing the code segment? (If you get stuck, try this `visualization <https://pythontutor.com/render.html#code=public%20class%20Liquid%20%7B%0A%20%20%0A%20%20%20%20private%20double%20boilingPoint%3B%0A%20%20%20%20private%20double%20freezingPoint%3B%0A%20%20%20%20private%20double%20currentTemp%3B%0A%0A%20%20%20%20public%20Liquid%28%29%0A%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20currentTemp%20%3D%2050%3B%0A%20%20%20%20%7D%0A%0A%20%20%20%20public%20void%20lowerTemp%28%29%0A%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20currentTemp%20-%3D%2010%3B%0A%20%20%20%20%7D%0A%0A%20%20%20%20public%20double%20getTemp%28%29%0A%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20return%20currentTemp%3B%0A%20%20%20%20%7D%0A%20%20%20%20%0A%20%20%20%20public%20static%20void%20main%28String%5B%5D%20args%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20Liquid%20water%20%3D%20new%20Liquid%28%29%3B%0A%20%20%20%20%20%20%20%20%20%20water.lowerTemp%28%29%3B%0A%20%20%20%20%20%20%20%20%20%20System.out.println%28water.getTemp%28%29%29%3B%0A%20%20%20%20%7D%0A%7D&cumulative=false&curInstr=18&heapPrimitives=nevernest&mode=display&origin=opt-frontend.js&py=java&rawInputLstJSON=%5B%5D&textReferences=false>`_ to see this code in action.)
 
     - \-10
 
@@ -734,6 +718,4 @@ AP Practice
 
       + Correct, the Liquid() constructor sets the currentTemp instance variable to 50, and the lowerTemp() method subtracts 10 from it, and getTemp() returns the currentTemp value as a double.
 
-.. |visualizationLiquid| raw:: html
 
-   <a href="https://pythontutor.com/render.html#code=public%20class%20Liquid%20%7B%0A%20%20%0A%20%20%20%20private%20double%20boilingPoint%3B%0A%20%20%20%20private%20double%20freezingPoint%3B%0A%20%20%20%20private%20double%20currentTemp%3B%0A%0A%20%20%20%20public%20Liquid%28%29%0A%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20currentTemp%20%3D%2050%3B%0A%20%20%20%20%7D%0A%0A%20%20%20%20public%20void%20lowerTemp%28%29%0A%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20currentTemp%20-%3D%2010%3B%0A%20%20%20%20%7D%0A%0A%20%20%20%20public%20double%20getTemp%28%29%0A%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20return%20currentTemp%3B%0A%20%20%20%20%7D%0A%20%20%20%20%0A%20%20%20%20public%20static%20void%20main%28String%5B%5D%20args%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20Liquid%20water%20%3D%20new%20Liquid%28%29%3B%0A%20%20%20%20%20%20%20%20%20%20water.lowerTemp%28%29%3B%0A%20%20%20%20%20%20%20%20%20%20System.out.println%28water.getTemp%28%29%29%3B%0A%20%20%20%20%7D%0A%7D&cumulative=false&curInstr=18&heapPrimitives=nevernest&mode=display&origin=opt-frontend.js&py=java&rawInputLstJSON=%5B%5D&textReferences=false" target="_blank">visualization</a>

--- a/_sources/Unit1-Using-Objects-and-Methods/topic-2-7-string-methods.rst
+++ b/_sources/Unit1-Using-Objects-and-Methods/topic-2-7-string-methods.rst
@@ -4,9 +4,6 @@
    :prefix: 2-7-
    :start: 1
 
-.. |AP CSA Reference Sheet| raw:: html
-
-   <a href="https://apstudents.collegeboard.org/ap/pdf/ap-computer-science-a-java-quick-reference_0.pdf" target="_blank">AP CSA Java Quick Reference Sheet</a>
 
 ..  |Time90|
 
@@ -35,7 +32,7 @@ A string holds characters in a sequence.  Each character is at a position or **i
 
    The first character in a string is at index 0 and the last characters is at **length** -1.
 
-For the AP CSA exam, you only need to know how to use the following String methods.  All of the String method descriptions are included in the |AP CSA Reference Sheet| that you get during the exam so you don't have to memorize these.
+For the AP CSA exam, you only need to know how to use the following String methods.  All of the String method descriptions are included in the `AP CSA Java Quick Reference Sheet <https://apstudents.collegeboard.org/ap/pdf/ap-computer-science-a-java-quick-reference_0.pdf>`_ that you get during the exam so you don't have to memorize these.
 
 
     -  **int length()** method returns the number of characters in the string, including spaces and special characters like punctuation.
@@ -251,11 +248,8 @@ Run the example below to see the output from ``compareTo`` and ``equals``. Since
        }
    }
 
-.. |String class| raw:: html
 
-   <a href="http://docs.oracle.com/javase/7/docs/api/java/lang/String.html" target="_blank">String class</a>
-
-There are lots of other methods in the String class.  You can look through the Java documentation for the |String class| online.   You don't have to know all of these for the exam, but you can use them if you want to on the exam.
+There are lots of other methods in the String class.  You can look through the Java documentation for the `String class <http://docs.oracle.com/javase/7/docs/api/java/lang/String.html>`_ online.   You don't have to know all of these for the exam, but you can use them if you want to on the exam.
 
 An **Application Programming Interface (API)** is a library of prewritten classes that simplify complex programming tasks for us. These classes are grouped together in a **package** like java.lang and we can import these packages (or individual classes) into our programs to make use of them. For instance, we have just discussed the String library built into the default java.lang package - it takes care of the detailed work of manipulating strings for us.  There are many other useful library packages as well, both in the java.lang package and in other packages. Documentation for APIs and libraries are essential to understanding how to use these classes.
 
@@ -446,16 +440,9 @@ Here is a list of common mistakes made with Strings.
 
 Create a program that takes a word and transforms it to Pig Latin using String methods. You may need the word's length, a substring that does not include the first letter, and a substring that is just the first letter (you can get the ith letter of a string using substring(i,i+1) so for example the letter at index 3 would be substring(3,4)).
 
-.. |repl| raw:: html
-
-   <a href="https://replit.com" target="_blank">replit.com</a>
 
 
-.. |Scanner| raw:: html
-
-   <a href="https://www.w3schools.com/java/java_user_input.asp" target="_blank">Scanner class</a>
-
-Your teacher may ask you to create this program in a Java IDE like |repl| so that you can use input to read in the word (see input examples using the |Scanner|).
+Your teacher may ask you to create this program in a Java IDE like `replit.com <https://replit.com>`_ so that you can use input to read in the word (see input examples using the `Scanner class <https://www.w3schools.com/java/java_user_input.asp>`_).
 
 
 .. activecode:: challenge2-7-PigLatin
@@ -526,7 +513,7 @@ Summary
 
 - String objects are **immutable**, meaning that String methods do not change the String object. Any method that seems to change a string actually creates a new string.
 
-- The following String methods and constructors, including what they do and when they are used, are part of the |AP CSA Reference Sheet| that you can use during the exam:
+- The following String methods and constructors, including what they do and when they are used, are part of the `AP CSA Java Quick Reference Sheet <https://apstudents.collegeboard.org/ap/pdf/ap-computer-science-a-java-quick-reference_0.pdf>`_ that you can use during the exam:
 
   - **String(String str)** : Constructs a new String object that represents the same sequence of characters as str.
 
@@ -547,10 +534,6 @@ Summary
 
 String Methods Game
 ---------------------------
-
-.. |game| raw:: html
-
-   <a href="https://csa-games.netlify.app/" target="_blank">game</a>
 
 
 Try the game below written by AP CSA teacher Chandan Sarkar. Click on **Strings** and then on the letters that would be the result of the string method calls. We encourage you to work in pairs and see how high a score you can get.

--- a/_sources/Unit1-Using-Objects-and-Methods/unit1a-summary.rst
+++ b/_sources/Unit1-Using-Objects-and-Methods/unit1a-summary.rst
@@ -81,12 +81,8 @@ Vocabulary Practice
 
     Drag the definition from the left and drop it on the correct concept on the right.  Click the "Check Me" button to see if you are correct.
 
-.. |Quizlet| raw:: html
 
-   <a href="https://quizlet.com/433933862/cs-awesome-unit-1-vocabulary-flash-cards/" target="_blank" style="text-decoration:underline">Quizlet</a>
-
-
-For more practice, see this |Quizlet| embedded below.
+For more practice, see this `Quizlet <https://quizlet.com/433933862/cs-awesome-unit-1-vocabulary-flash-cards/>`_ embedded below.
 
 .. raw:: html
 

--- a/_sources/Unit1-Using-Objects-and-Methods/unit1b-summary.rst
+++ b/_sources/Unit1-Using-Objects-and-Methods/unit1b-summary.rst
@@ -100,12 +100,8 @@ Vocabulary Practice
     Drag the definition from the left and drop it on the correct concept on the right.  Click the "Check Me" button to see if you are correct.
 
 
-.. |Quizlet| raw:: html
 
-   <a href="https://quizlet.com/434063730/cs-awesome-unit-2-vocabulary-flash-cards/" target="_blank" style="text-decoration:underline">Quizlet</a>
-
-
-For more practice, see this |Quizlet| embedded below.
+For more practice, see this `Quizlet <https://quizlet.com/434063730/cs-awesome-unit-2-vocabulary-flash-cards/>`_ embedded below.
 
 .. raw:: html
 

--- a/_sources/index.rst
+++ b/_sources/index.rst
@@ -7,16 +7,12 @@ CSAwesome2 AP CSA Java Course with College Board 2025-6 Revisions
 
 Welcome to CSAwesome2! It's time to start your journey to learn how to program with Java. A shortcut way to get to this site is to type in the url: **course.csawesome.org**
 
-CSAwesome is a College Board endorsed curriculum for AP Computer Science A, an introductory college-level computer programming course in Java.  If you are a teacher using this curriculum, please join the |teaching CSAwesome group| which will give you access to teacher resources at |csawesome|.
+CSAwesome is a College Board endorsed curriculum for AP Computer Science A, an introductory college-level computer programming course in Java.  If you are a teacher using this curriculum, please join the `teaching CSAwesome group <https://groups.google.com/forum/#!forum/teaching-csawesome>`_ which will give you access to teacher resources at `csawesome.org <http://csawesome.org>`_.
 
 To make sure the site saves your answers on questions, please click on the person icon at the top to register or login to your Runestone course. As you complete lessons, click the "Mark as completed" button at the bottom. Enjoy the journey!
 
-.. |flyer| raw:: html
 
-   <a href="https://drive.google.com/file/d/11MDPfpb3sjzfCR-6zeUe79WNgBbfZbqN/view?usp=sharing" target="_blank" style="text-decoration:underline">flyer</a>
-
-
-ATTENTION high school women of color taking AP CSA or CSP: if you identify as female and as Black, Hispanic/Latina, and/or Native American, apply to participate in **Sisters Rise Up**. The goal of Sisters Rise Up is to help you succeed in your AP Computer Science course and on the exam. They offer one-hour help sessions several times a week and once a month special help sessions often with guest speakers from computing.  If you enroll in Sisters Rise Up and send in your AP CS exam score by the end of August, you will be sent a gift card for $100. See the |flyer| and apply at https://tinyurl.com/55z7tyb9.
+ATTENTION high school women of color taking AP CSA or CSP: if you identify as female and as Black, Hispanic/Latina, and/or Native American, apply to participate in **Sisters Rise Up**. The goal of Sisters Rise Up is to help you succeed in your AP Computer Science course and on the exam. They offer one-hour help sessions several times a week and once a month special help sessions often with guest speakers from computing.  If you enroll in Sisters Rise Up and send in your AP CS exam score by the end of August, you will be sent a gift card for $100. See the `flyer <https://drive.google.com/file/d/11MDPfpb3sjzfCR-6zeUe79WNgBbfZbqN/view?usp=sharing>`_ and apply at https://tinyurl.com/55z7tyb9.
 
 .. ATTENTION high school women, genderqueer, and non-binary technologists: Apply Sept. 1st until Oct. 20th for the **NCWIT Award for Aspirations in Computing** to be recognized for all that you do (or want to do) in technology. Visit http://www.aspirations.org/AiCHSAward for details. 
 
@@ -68,23 +64,11 @@ Index
 * :ref:`genindex`
 * :ref:`search`
 
-.. |errors form| raw:: html
 
-   <a href="https://forms.gle/4gMBsv4W71vG5mNe8" target="_blank" style="text-decoration:underline">errors form</a>
 
-.. |interest form| raw:: html
 
-   <a href="https://docs.google.com/forms/d/e/1FAIpQLSdN4JKrFnktQakID4sHBHBuBEHCvwv8YsSMBcVm1tB-nYUukA/viewform?usp=sf_link" target="_blank" style="text-decoration:underline">PD interest form</a>
 
-.. |teaching CSAwesome group| raw:: html
-
-   <a href="https://groups.google.com/forum/#!forum/teaching-csawesome" target="_blank" style="text-decoration:underline">teaching CSAwesome group</a>
-
-.. |csawesome| raw:: html
-
-   <a href="http://csawesome.org" target="_blank" style="text-decoration:underline">csawesome.org</a>
-
-If you see errors or bugs, please report them with this |errors form|. If you are a teacher who is interested in CSAwesome PDs or community, please fill out this |interest form| and join the |teaching CSAwesome group| which will give you access to lesson plans at |csawesome|.
+If you see errors or bugs, please report them with this `errors form <https://forms.gle/4gMBsv4W71vG5mNe8>`_. If you are a teacher who is interested in CSAwesome PDs or community, please fill out this `PD interest form <https://docs.google.com/forms/d/e/1FAIpQLSdN4JKrFnktQakID4sHBHBuBEHCvwv8YsSMBcVm1tB-nYUukA/viewform?usp=sf_link>`_ and join the `teaching CSAwesome group <https://groups.google.com/forum/#!forum/teaching-csawesome>`_ which will give you access to lesson plans at `csawesome.org <http://csawesome.org>`_.
 
 (last revised 1/6/2024)
 

--- a/fix-raw-html-links.pl
+++ b/fix-raw-html-links.pl
@@ -15,13 +15,19 @@ my %texts;
 
 while (<>) {
 
-  while (s/^\s*^\.\.\s+\|([^\|]+?)\|[ \t]+raw::\s+html\s+<a href\s*=\s*"(.*?)".*?>(.*?)<\/a>\s+/\n/msg) {
+  # Find all the raw:: html links and stash them away
+  while (/^\.\.\s+\|([^\|]+?)\|[ \t]+raw::[ \t]+html\s+<a href\s*=\s*"(.*?)".*?>(.*?)<\/a>\s+/msg) {
+    print STDERR "Found link $1.\n";
     $urls{$1} = $2;
     $texts{$1} = $3;
   }
 
+  # Now remove the definitions
+  s/^\.\.\s+\|([^\|]+?)\|[ \t]+raw::[ \t]+html\s+<a href\s*=\s*"(.*?)".*?>(.*?)<\/a>\s+/\n/msg;
+
+  # And now replace the references to the raw:: html sections
   foreach my $slug (keys %urls) {
-    print STDERR "Replacing ", substr($slug, 0, 20), " in $ARGV\n";
+    print STDERR "Replacing ", $slug, " in $ARGV\n";
     s{\|$slug\|}{'`' . $texts{$slug} . ' <' . $urls{$slug} . '>`_'}ge;
   }
 

--- a/fix-raw-html-links.pl
+++ b/fix-raw-html-links.pl
@@ -1,0 +1,29 @@
+#!/usr/bin/env perl
+
+#
+# Fix all the raw:: html links in the rst.
+#
+
+use warnings;
+use strict;
+
+$/ = undef;
+$^I = '';
+
+my %urls;
+my %texts;
+
+while (<>) {
+
+  while (s/^\s*^\.\.\s+\|([^\|]+?)\|[ \t]+raw::\s+html\s+<a href\s*=\s*"(.*?)".*?>(.*?)<\/a>\s+/\n/msg) {
+    $urls{$1} = $2;
+    $texts{$1} = $3;
+  }
+
+  foreach my $slug (keys %urls) {
+    print STDERR "Replacing ", substr($slug, 0, 20), " in $ARGV\n";
+    s{\|$slug\|}{'`' . $texts{$slug} . ' <' . $urls{$slug} . '>`_'}ge;
+  }
+
+  print;
+}


### PR DESCRIPTION
This script fixes just the `raw:: html` elements that are used to add `<a>` elements which is most of the uses of `raw:: html`, at least in these two chapters.

I did it in the rst sources rather than in the XML because by the time the rst has been converted to XML the raw html has been turned into escaped gobbledygook. This does slightly change the semantics rst source insofar is it would now generate links without the `target="_blank"` if we used the rst to generate HTML directly. But that seems okay to me.
