### PR TITLE
Changes made to fix-xml to build successfully

### DIFF
--- a/_sources/Unit0-Getting-Started/preface.rst
+++ b/_sources/Unit0-Getting-Started/preface.rst
@@ -67,6 +67,7 @@ Several students at Georgia Tech have helped review the eBook:
 * Stephanie Remy
 
 Several students from the University of Michigan have contributed to the eBook
+
 * Emma Brown - unit tests
 * Emma Pinnell - unit tests
 * Kira Woodhouse - Added Peer Instruction questions

--- a/_sources/Unit0-Getting-Started/toctree.rst
+++ b/_sources/Unit0-Getting-Started/toctree.rst
@@ -16,5 +16,5 @@ Follow the links below to learn more about the AP CSA course and exam and Java d
    javaIDEs.rst
    growthMindset.rst
    ptest1.rst
-   survey.rst
+
 

--- a/fix-xml.pl
+++ b/fix-xml.pl
@@ -42,6 +42,12 @@ while (<>) {
   s/i <"/i &lt;"/g;
   s/"<img /"&lt;img /g;
 
+  # BH added to get rid of html or < in program comments and <E>
+  s/^\s*\*\s*<(.*)</\* &lt;$1&lt;/g;
+  s/^\s*\*\s*</\* &lt;/g;
+  s/^\s*\*(.*)</\*$1&lt;/g;
+  s/<E>/&lt;E>/g;
+
   # Not sure what's up with this; Some of these data-optional things are
   # generated within strings of what look like JSON. Anyway, these two lines at
   # least mangle it into acceptable XML.


### PR DESCRIPTION
I had to add some substitutions to fix-xml.pl to do `make all` without errors.  They were to catch html tags or < in a comment in a program. I also made 2 small manual changes to 2 rst files to avoid errors. We can change them in main too.