### PR TITLE
Reduce the amount of fixup work the Makefile does.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,18 +9,33 @@ endif
 
 DEBUG_PRETEXT := # -v DEBUG
 
-xml := $(if $(wildcard build/xml),$(shell find build/xml -type f))
+# The root of everything
+sources := $(shell find _sources -type f)
+
+# After we fix them with the fix'em scripts
+fixed_sources := $(patsubst _sources/%,_fixed_sources/%,$(sources))
+
+# Then we generate XML for each rst file except for common.rst
+xml := $(patsubst _fixed_sources/%.rst,build/xml/%.xml,$(filter-out _fixed_sources/common.rst,$(fixed_sources)))
+
+# And then each xml file is eventually turned into ptx
 ptx := $(patsubst build/xml/%.xml,pretext/%.ptx,$(xml))
 
 # This will run from a virtual env.
-rs2ptx := python -m runestone rs2ptx
+rs2ptx := python -m runestone rs2ptx --sourcedir _fixed_sources
 
 all: fixed_source fixed_xml
-	$(MAKE) ptx post fixed_ptx build_$(TARGET)
+	$(MAKE) fixed_ptx build_$(TARGET)
 
-fixed_source:
-	find _sources/ -name '*.rst' -exec ./fix-raw-html-links.pl {} \;
-	find _sources/ -name '*.rst' -exec ./fix-source.pl {} \;
+fixed_source: $(fixed_sources)
+
+_fixed_sources/%: _sources/% | _fixed_sources
+	mkdir -p $(dir $@)
+	./fix-raw-html-links.pl --debug $< > $@
+	./fix-source.pl $@
+
+_fixed_sources:
+	mkdir $@
 
 xml:
 	$(rs2ptx)
@@ -30,33 +45,39 @@ fixed_xml: xml
 	find build/xml -name '*.xml' -exec ./fix-xml.pl {} \;
 	./fixIds.py build/xml ".xml"
 
-fixed_ptx:
+fixed_ptx: post
 	find pretext -name '*.ptx' -exec ./fix-ptx.pl {} \;
 	find pretext -name '*.ptx' -exec ./fix-tests.pl {} \;
 	if [ -d hand-fixes ]; then rsync -r hand-fixes/ pretext/; fi
 
 # This works better than the script that does them all
-pretext/%.ptx: build/xml/%.xml | pretext
+pretext/%.ptx: XMLFILE = $(patsubst _fixed_sources/%.rst,build/xml/%.xml,$<)
+pretext/%.ptx: _fixed_sources/%.rst | build/xml/%.xml pretext
 	mkdir -p $(dir $@)
-	xsltproc --novalid $(R2P)/docutils2ptx.xsl $< > $<.pass1
-	./fixIds.py build/xml ".xml.pass1"
-	xsltproc --novalid post-1.xsl $<.pass1 > $<.pass2
-	xsltproc --novalid post-2.xsl $<.pass2 > $<.pass3
-	xsltproc --novalid post-3.xsl $<.pass3 > $@
+	xsltproc --novalid $(R2P)/docutils2ptx.xsl $(XMLFILE) > $(XMLFILE).pass1
+	xsltproc --novalid post-1.xsl $(XMLFILE).pass1 > $(XMLFILE).pass2
+	xsltproc --novalid post-2.xsl $(XMLFILE).pass2 > $(XMLFILE).pass3
+	xsltproc --novalid post-3.xsl $(XMLFILE).pass3 > $@
+
+pretext/rs-substitutes.xml: rs-substitutes.xml | pretext
+	cp $< $@
+
+pretext:
+	mkdir $@
 
 ptx: $(ptx) pretext/rs-substitutes.xml
 
 # need to do pretext init in here to generate project.ptx
 # need to manually edit project.ptx and create publication-rs-for-all.xml
 #   as described in https://github.com/bnmnetp/Runestone2PreTeXt/blob/main/README.md
-post:
+post: ptx
 	./fixIds.py pretext .ptx
 	python $(R2P)/fix_xrefs.py
 	python $(R2P)/reformatPtx.py
 	python $(R2P)/index2main.py
-	python $(R2P)/toctree2xml.py .
-	python $(R2P)/filltoc.py pretext _sources
-	python $(R2P)/copy_figs.py ./_sources ./pretext/assets
+	python $(R2P)/toctree2xml.py . _fixed_sources
+	python $(R2P)/filltoc.py pretext _fixed_sources
+	python $(R2P)/copy_figs.py ./_fixed_sources ./pretext/assets
 
 restore:
 	git restore pretext
@@ -73,14 +94,8 @@ build_web:
 build_runestone:
 	pretext $(DEBUG_PRETEXT) build runestone
 
-pretext:
-	mkdir $@
-
-pretext/rs-substitutes.xml: rs-substitutes.xml | pretext
-	cp $< $@
-
 clean: restore
 	rm -rf build/xml
 
 pristine: clean
-	git restore _sources
+	rm -rf _fixed_sources


### PR DESCRIPTION
This change tries to make the `Makefile` more efficient in the case where you've just edited a couple rst files and want to rebuild. It's actually a bit slower for a full build because it doesn't fix the source in bulk anymore. But if you just touch one rst file it will update the fixed source version of that (which now lives in a separate directory) and then will only generate the corresponding ptx file if the fixed source is newer.

The parts I don't control, `rs2ptx` and `pretext build` still work on everything every time so will be as slow as ever.