### PR TITLE
Script additions for dealing with tests and _static images

### DIFF
--- a/fix-ptx.pl
+++ b/fix-ptx.pl
@@ -21,5 +21,10 @@ while (<>) {
   s/xml:id="_carla-de-lira-id1(-\d+)?"/xml:id="interviewees_c_-de_-lira"/g;
   s/xml:id="_camille-mbayo-id1(-\d+)?"/xml:id="interviewees_c_-mbayo"/g;
 
+  # For tests, put in time-limit to have it generate as a test. Pretests are no-feedback.
+  # There are some with 'timelimit': 45, but we could make them all untimed.
+  s/<exercises line=.*nofeedback.*>/<exercises time-limit="" feedback="no">/g;
+  s/<exercises line=.*(test|exam|midterm).*>/<exercises time-limit="">/g;
+ 
   print;
 }

--- a/fix-xml.pl
+++ b/fix-xml.pl
@@ -48,6 +48,9 @@ while (<>) {
   s/^\s*\*(.*)</\*$1&lt;/g;
   s/<E>/&lt;E&gt;/g;
 
+  # BH added to remove .. from ../_static image paths
+  s/\.\.\/\_static/\_static/g;
+
   # Not sure what's up with this; Some of these data-optional things are
   # generated within strings of what look like JSON. Anyway, these two lines at
   # least mangle it into acceptable XML.

--- a/fix-xml.pl
+++ b/fix-xml.pl
@@ -51,6 +51,9 @@ while (<>) {
   # BH added to remove .. from ../_static image paths
   s/\.\.\/\_static/\_static/g;
 
+  # BH added to remove xml-id from paragraphs
+  s/<paragraph ids=".*">/<paragraph>/g;
+
   # Not sure what's up with this; Some of these data-optional things are
   # generated within strings of what look like JSON. Anyway, these two lines at
   # least mangle it into acceptable XML.


### PR DESCRIPTION
I think these work to fix tests and images and to delete the paragraph xml:ids.
I added the time-limit attribute to <exercises> to make it generate as a test, but they can only be tested on a Runestone server (pre-test in Unit 0).
I removed the ../ in front of ../_static for static image paths.
And I deleted xml:id's from paragraphs. We could probably delete more.