### PR TITLE
Remove post2.xsl px to % conversion

### DIFF
--- a/post-2.xsl
+++ b/post-2.xsl
@@ -41,13 +41,13 @@
 
   <xsl:template match="p/br" />
 
-  <!-- fix up width attributes to be percentages --> 
+  <!-- fix up width attributes to be percentages  - now done in fix-xml.py
   <xsl:template match="@width">
     <xsl:attribute name="width">
       <xsl:value-of select="round((. div 850) * 100)"/>
       <xsl:text>%</xsl:text>
     </xsl:attribute>
   </xsl:template>
-
+--> 
   
 </xsl:stylesheet>


### PR DESCRIPTION
It looks like last year, you did the px to % conversion for images in post2.xsl. 
This year, you are doing this in fix-xml.pl. 
I commented it out in post2 because it adds extra stuff that gets translated as NaN%.