### PR TITLE
Hacks to delete some xml:ids

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ build_info
 build
 .github/*
 sphinx_settings.json
+_fixed_sources/*
 
 # Miscellaneous source files
 _sources/Tests/test6.rst

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,8 @@ xml:
 
 fixed_xml: xml
 	find build/xml -name '*.xml' -exec ./fix-xml.pl {} \;
-	./fixIds.py build/xml ".xml"
+
+# BH removed fixIds ./fixIds.py build/xml ".xml"
 
 fixed_ptx: post
 	find pretext -name '*.ptx' -exec ./fix-ptx.pl {} \;
@@ -70,8 +71,8 @@ ptx: $(ptx) pretext/rs-substitutes.xml
 # need to do pretext init in here to generate project.ptx
 # need to manually edit project.ptx and create publication-rs-for-all.xml
 #   as described in https://github.com/bnmnetp/Runestone2PreTeXt/blob/main/README.md
+# BH removed fixIds ./fixIds.py pretext ".ptx"
 post: ptx
-	./fixIds.py pretext .ptx
 	python $(R2P)/fix_xrefs.py
 	python $(R2P)/reformatPtx.py
 	python $(R2P)/index2main.py

--- a/fix-ptx.pl
+++ b/fix-ptx.pl
@@ -26,5 +26,10 @@ while (<>) {
   s/<exercises line=.*nofeedback.*>/<exercises time-limit="" feedback="no">/g;
   s/<exercises line=.*(test|exam|midterm).*>/<exercises time-limit="">/g;
  
+  # BH: remove xml-ids from subsection because lots of duplicates 
+  s/<subsection xml:id=".*?"/<subsection /g;
+  # remove _ in section ids 
+  s/<section xml:id="_/<section xml:id="/g;
+  
   print;
 }

--- a/fix-xml.pl
+++ b/fix-xml.pl
@@ -51,8 +51,18 @@ while (<>) {
   # BH added to remove .. from ../_static image paths
   s/\.\.\/\_static/\_static/g;
 
-  # BH added to remove xml-id from paragraphs
+  # BH added to remove xml-id from paragraphs, programs, videos, figures
   s/<paragraph ids=".*?">/<paragraph>/g;
+  s/<program xml:id=".*?"/<program /g;
+  s/<video xml:id=".*?"/<video /g;
+  s/<target(.*?)ids=".*?"/<target$1 /g;
+  s/<figure(.*?)ids=".*?"/<figure$1 /g;
+  s/<problematic(.*?)ids=".*?"/<problematic$1 /g;
+  s/<image(.*?)ids=".*?"/<image$1 /g;
+  # remove space in ids
+  s/ids="(.*?)\s(.*?)"/ids="$1$2"/g;
+  # not sure where the lack of space comes in here ids=""names=""
+  s/"names=/" names=/g;
 
   # Not sure what's up with this; Some of these data-optional things are
   # generated within strings of what look like JSON. Anyway, these two lines at

--- a/pretext/assets/custom-css.css
+++ b/pretext/assets/custom-css.css
@@ -2,3 +2,7 @@
 details.ptx-footnote {
   display: none;
 }
+/* hack to align |CodingEx| type images */
+img .contained {
+  float: left;
+}


### PR DESCRIPTION
This is my attempt to keep the section xml:id's but delete the rest, so that we get less errors and the html file names match the section titles which become the xml:ids. There are still some duplicates section titles/xml:ids like Exercises, but maybe it doesn't really matter if we are not going to refer back to the ambiguous ones.  
There is probably a better way to do this. Ideas welcome.