### PR TITLE
Remove extraneous xml:ids in XSLT step.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ build_info
 build
 .github/*
 sphinx_settings.json
+_fixed_sources/*
 
 # Miscellaneous source files
 _sources/Tests/test6.rst

--- a/fixIds.py
+++ b/fixIds.py
@@ -32,6 +32,9 @@ def uniquify(text):
     seen[text] += 1
     return text if c == 0 else f"{text}-{c}"
 
+def rewrite_and_uniquify(m):
+    return uniquify(rewrite_id_old(m))
+
 
 for root, dirs, files in os.walk(directory):
     for file in files:
@@ -40,7 +43,7 @@ for root, dirs, files in os.walk(directory):
         if file.endswith(ext):
             with open(os.path.join(root, file)) as f:
                 text = f.read()
-            text = re.sub(r'xml:id="(.*?)"', rewrite_id, text)
+            text = re.sub(r'xml:id="(.*?)"', rewrite_and_uniquify, text)
 
             with open(os.path.join(root, file), "w") as f:
                 f.write(text)

--- a/post-1.xsl
+++ b/post-1.xsl
@@ -7,6 +7,14 @@
     </xsl:copy>
   </xsl:template>
 
+  <!-- Remove xml:id attribute from all elements except 'section' -->
+  <xsl:template match="@xml:id[not(parent::section)]"/>
+
+  <!-- Explicitly keep xml:id on 'section' elements -->
+  <xsl:template match="section/@xml:id">
+    <xsl:copy-of select="."/>
+  </xsl:template>
+
   <xsl:template match="section[exercise]">
     <xsl:copy>
       <xsl:apply-templates select="*[not(name() = 'exercise')]" />


### PR DESCRIPTION
I think this is maybe a better way to get rid of all the xml:ids other than the ones on `<section>` elements. In general if we can transform XML as XML rather than as text that will be more robust. 