### PR TITLE
Fixing some URLs

### DIFF
--- a/format-ptx.py
+++ b/format-ptx.py
@@ -209,7 +209,7 @@ def reformat(filename, inplace):
 
     print('<?xml version="1.0" encoding="UTF-8"?>', file=f)
     for e in document_elements(root):
-        print(serialize_element(e), file=f)
+        print(serialize_element(e).rstrip(), file=f)
 
 
 if __name__ == "__main__":

--- a/format-ptx.py
+++ b/format-ptx.py
@@ -221,11 +221,18 @@ if __name__ == "__main__":
         description="Reformat PreText XML to be semi-human-digestible.",
     )
 
-    parser.add_argument("filename", help="File to reformat")
     parser.add_argument(
-        "-i", "--inplace", action="store_true", help="Reformat in place"
+        "-i", "--inplace", action="store_true", help="Reformat in place")
+    parser.add_argument(
+        "-q", "--quiet", action="store_true", help="Don't emit output about files."
     )
+    parser.add_argument("files", nargs="*", help="Files to reformat")
 
     args = parser.parse_args()
 
-    reformat(args.filename, args.inplace)
+    for f in args.files:
+        if not args.quiet:
+            print(f"{f} ... ", file=stderr, end="")
+        reformat(f, args.inplace)
+        if not args.quiet:
+            print("ok.", file=stderr)

--- a/format-ptx.py
+++ b/format-ptx.py
@@ -11,7 +11,7 @@ from lxml import etree
 INDENT = 2
 WIDTH = 80
 INLINE_TAGS = {"term", "url", "c", "h", "area"}
-PRESERVE_WHITESPACE = {"code", "cline", "tests"}
+PRESERVE_WHITESPACE = {"code", "cline", "tests", "pre"}
 ONE_LINE = {"cline"}
 WRAP = {"p", "caption"}
 DEFAULT_NS = {"xml": "http://www.w3.org/XML/1998/namespace"}

--- a/format-ptx.py
+++ b/format-ptx.py
@@ -112,7 +112,7 @@ def render_block(elem, ns, level=0):
     if is_empty(elem):
         return f"\n{indent(level)}{open_tag(elem, ns, empty=True)}"
     elif is_just_short_text(elem):
-        return f"{tag}{escape((elem.text or '').strip())}{close_tag(elem, ns)}"
+        return f"{tag}{escape(clean_text(elem.text or ''))}{close_tag(elem, ns)}"
     else:
         content = ""
 
@@ -125,16 +125,19 @@ def render_block(elem, ns, level=0):
                 content += escape(child.tail)
 
         if wrappable(elem):
-            content = re.sub(r"\s+", " ", content)
-            filled = fill_with_indent(content.strip(), indent(level + 1))
+            filled = fill_with_indent(content, indent(level + 1))
             return f"{tag}\n{filled}\n{indent(level)}{close_tag(elem, ns)}\n"
         else:
             return f"{tag}\n{indent(level + 1)}{content.strip()}\n{indent(level)}{close_tag(elem, ns)}\n"
 
 
+def clean_text(s):
+    return re.sub(r"\s+", " ", s.strip())
+
+
 def fill_with_indent(text, i):
     return fill(
-        text.strip(),
+        clean_text(text),
         width=WIDTH,
         initial_indent=i,
         subsequent_indent=i,

--- a/format-ptx.py
+++ b/format-ptx.py
@@ -139,6 +139,7 @@ def fill_with_indent(text, i):
         initial_indent=i,
         subsequent_indent=i,
         break_long_words=False,
+        break_on_hyphens=False,
     )
 
 

--- a/pretext/Unit1-Using-Objects-and-Methods/Exercises-basics.ptx
+++ b/pretext/Unit1-Using-Objects-and-Methods/Exercises-basics.ptx
@@ -292,7 +292,7 @@ b = (int) a;
         </statement>
 
         <feedback>
-          <p>This would be true if it was b = a.  What does the (int) do?</p>
+          <p>This would be true if it was b = a. What does the (int) do?</p>
         </feedback>
       </choice>
 

--- a/pretext/Unit1-Using-Objects-and-Methods/Exercises-basics.ptx
+++ b/pretext/Unit1-Using-Objects-and-Methods/Exercises-basics.ptx
@@ -530,4 +530,3 @@ x++;
     </choices>
   </activity>
 </section>
-

--- a/pretext/Unit1-Using-Objects-and-Methods/Exercises-objects.ptx
+++ b/pretext/Unit1-Using-Objects-and-Methods/Exercises-objects.ptx
@@ -1578,7 +1578,7 @@ System.out.println("13" + 5 + 3);
           </statement>
 
           <feedback>
-            <p>You can append a number to a string in Java.  It will compile.</p>
+            <p>You can append a number to a string in Java. It will compile.</p>
           </feedback>
         </choice>
       </choices>

--- a/pretext/Unit1-Using-Objects-and-Methods/Exercises-objects.ptx
+++ b/pretext/Unit1-Using-Objects-and-Methods/Exercises-objects.ptx
@@ -1735,4 +1735,3 @@ public class MainClass
     </activity>
   </subsection>
 </section>
-

--- a/pretext/Unit1-Using-Objects-and-Methods/JavaSwingGUIs.ptx
+++ b/pretext/Unit1-Using-Objects-and-Methods/JavaSwingGUIs.ptx
@@ -112,9 +112,8 @@ frame.add(button1);
 
   <p>
     To learn more about Java Swing, click on the different Swing components in
-    the left navigation column of <url href="https://www.javatpoint.com/java-
-    swing" visual="https://www.javatpoint.com/java-
-    swing">https://www.javatpoint.com/java-swing</url> and try them out!
+    the left navigation column of <url
+    href="https://www.javatpoint.com/java-swing">https://www.javatpoint.com/java-swing</url>
+    and try them out!
   </p>
 </section>
-

--- a/pretext/Unit1-Using-Objects-and-Methods/frq-practice.ptx
+++ b/pretext/Unit1-Using-Objects-and-Methods/frq-practice.ptx
@@ -182,4 +182,3 @@ public class RunestoneTests extends CodeTestHelper
     </activity>
   </subsection>
 </section>
-

--- a/pretext/Unit1-Using-Objects-and-Methods/practice-test-objects.ptx
+++ b/pretext/Unit1-Using-Objects-and-Methods/practice-test-objects.ptx
@@ -925,4 +925,3 @@ public int anotherThing(int i, int j)
     </exercise>
   </exercises>
 </section>
-

--- a/pretext/Unit1-Using-Objects-and-Methods/toctree.ptx
+++ b/pretext/Unit1-Using-Objects-and-Methods/toctree.ptx
@@ -82,4 +82,3 @@
   <xi:include href="./JavaSwingGUIs.ptx" />
   <xi:include href="./frq-practice.ptx" />
 </chapter>
-

--- a/pretext/Unit1-Using-Objects-and-Methods/topic-1-1-intro-algorithms.ptx
+++ b/pretext/Unit1-Using-Objects-and-Methods/topic-1-1-intro-algorithms.ptx
@@ -1089,9 +1089,11 @@ System.out.println("Unexpected '}' on line 32. ")  // Line 3;
         </p>
 
         <raw format="html" xml:space="preserve">
-          <pre>Roses are red,
+          <pre>
+Roses are red,
 Violets are blue,
-Unexpected '}' on line 32.</pre>
+Unexpected '}' on line 32.
+          </pre>
         </raw>
 
         <p>

--- a/pretext/Unit1-Using-Objects-and-Methods/topic-1-1-intro-algorithms.ptx
+++ b/pretext/Unit1-Using-Objects-and-Methods/topic-1-1-intro-algorithms.ptx
@@ -3836,4 +3836,3 @@ Unexpected '}' on line 32.</pre>
     </datafile>
   </subsection>
 </section>
-

--- a/pretext/Unit1-Using-Objects-and-Methods/topic-1-10-calling-class-methods.ptx
+++ b/pretext/Unit1-Using-Objects-and-Methods/topic-1-10-calling-class-methods.ptx
@@ -875,4 +875,3 @@ public void static printInCentimeters(double inches, double centimeters)
     </activity>
   </subsection>
 </section>
-

--- a/pretext/Unit1-Using-Objects-and-Methods/topic-1-10-calling-class-methods.ptx
+++ b/pretext/Unit1-Using-Objects-and-Methods/topic-1-10-calling-class-methods.ptx
@@ -831,7 +831,7 @@ public void static printInCentimeters(double inches, double centimeters)
 
         <choice>
           <statement id="AP1-10-static-method2_opt_b">
-            <p>10 –&gt;  25</p>
+            <p>10 –&gt; 25</p>
           </statement>
 
           <feedback id="AP1-10-static-method2_opt_b">

--- a/pretext/Unit1-Using-Objects-and-Methods/topic-1-12-objects.ptx
+++ b/pretext/Unit1-Using-Objects-and-Methods/topic-1-12-objects.ptx
@@ -356,14 +356,11 @@ Turtle myrtle;
       browser, you can also see the <c>Turtle</c> code in action on <url
       href="https://play.juicemind.com/dashboard/teams/Mk2wWMTqPkekcxTDWqRn/item/beca9c16-4004-4a4e-b4b0-11593e140808#f5357602-b60b-44c3-be0e-dfb07de2a778"
       visual="https://play.juicemind.com/dashboard/teams/Mk2wWMTqPkekcxTDWqRn/item/beca9c16-4004-4a4e-b4b0-11593e140808#f5357602-b60b-44c3-be0e-dfb07de2a778">JuiceMind</url>
-      or <url href="https://replit.com/@BerylHoffman/Java-Swing-
-      Turtle#Main.java" visual="https://replit.com/@BerylHoffman/Java-Swing-
-      Turtle#Main.java">replit</url> or download the files <url
-      href="https://github.com/bhoffman0/CSAwesome2/raw/main/_sources/Unit1-Using-
-      Objects-and-Methods/TurtleJavaSwingCode.zip"
-      visual="https://github.com/bhoffman0/CSAwesome2/raw/main/_sources/Unit1-Using-
-      Objects-and-Methods/TurtleJavaSwingCode.zip">here</url> to use in your own
-      IDE.
+      or <url
+      href="https://replit.com/@BerylHoffman/Java-Swing-Turtle#Main.java">replit</url>
+      or download the files <url
+      href="https://github.com/bhoffman0/CSAwesome2/raw/main/_sources/Unit1-Using-Objects-and-Methods/TurtleJavaSwingCode.zip">here</url>
+      to use in your own IDE.
     </p>
 
     <activity label="TurtleTest">

--- a/pretext/Unit1-Using-Objects-and-Methods/topic-1-13-constructors.ptx
+++ b/pretext/Unit1-Using-Objects-and-Methods/topic-1-13-constructors.ptx
@@ -1399,4 +1399,3 @@ public class Movie
     </activity>
   </subsection>
 </section>
-

--- a/pretext/Unit1-Using-Objects-and-Methods/topic-1-15-strings.ptx
+++ b/pretext/Unit1-Using-Objects-and-Methods/topic-1-15-strings.ptx
@@ -32,7 +32,7 @@
     <title>String References</title>
     <activity label="lcsb1">
       <statement>
-        <p>Run the following code.  What does it print?</p>
+        <p>Run the following code. What does it print?</p>
       </statement>
 
       <program interactive="activecode" language="java">

--- a/pretext/Unit1-Using-Objects-and-Methods/topic-1-2-variables.ptx
+++ b/pretext/Unit1-Using-Objects-and-Methods/topic-1-2-variables.ptx
@@ -1346,4 +1346,3 @@ double gpa = 3.5;
     </activity>
   </subsection>
 </section>
-

--- a/pretext/Unit1-Using-Objects-and-Methods/topic-1-3-expressions.ptx
+++ b/pretext/Unit1-Using-Objects-and-Methods/topic-1-3-expressions.ptx
@@ -268,10 +268,8 @@ public class RunestoneTests extends CodeTestHelper
       the Hubble Space Telescope was launched to space in 1990, a math coding
       error in a formula caused it to point in the wrong direction! It missed
       its target stars by about half a degree which is about the width of the
-      moon seen from Earth (<url href="https://scholar.lib.vt.edu/VA-news/ROA-
-      Times/issues/1990/rt9005/900510/05100615.htm"
-      visual="https://scholar.lib.vt.edu/VA-news/ROA-
-      Times/issues/1990/rt9005/900510/05100615.htm">https://scholar.lib.vt.edu/VA-
+      moon seen from Earth (<url
+      href="https://scholar.lib.vt.edu/VA-news/ROA-Times/issues/1990/rt9005/900510/05100615.htm">https://scholar.lib.vt.edu/VA-
       news/ROA-Times/issues/1990/rt9005/900510/05100615.htm</url>). Thorough
       testing is the only way to make sure there are no logic errors that will
       cause runtime errors in your code. Try the following example that tries to
@@ -963,4 +961,3 @@ System.out.println(5 + 5 / 2 * 3 - 1);
     </activity>
   </subsection>
 </section>
-

--- a/pretext/Unit1-Using-Objects-and-Methods/topic-1-3-expressions.ptx
+++ b/pretext/Unit1-Using-Objects-and-Methods/topic-1-3-expressions.ptx
@@ -827,7 +827,8 @@ System.out.print("and cool!");
         <choice>
           <statement id="AP1-3-1_opt_a">
             <p>
-              <pre>Java is fun and cool!</pre>
+              <pre>Java is fun and cool!
+              </pre>
             </p>
           </statement>
 
@@ -840,7 +841,8 @@ System.out.print("and cool!");
           <statement id="AP1-3-1_opt_b">
             <p>
               <pre>Java isfun
-and cool!</pre>
+and cool!
+              </pre>
             </p>
           </statement>
 
@@ -854,7 +856,8 @@ and cool!</pre>
             <p>
               <pre>Java is
 fun
-and cool!</pre>
+and cool!
+              </pre>
             </p>
           </statement>
 
@@ -867,7 +870,8 @@ and cool!</pre>
           <statement id="AP1-3-1_opt_d">
             <p>
               <pre>Java is fun
-and cool!</pre>
+and cool!
+              </pre>
             </p>
           </statement>
 

--- a/pretext/Unit1-Using-Objects-and-Methods/topic-1-4-assignment.ptx
+++ b/pretext/Unit1-Using-Objects-and-Methods/topic-1-4-assignment.ptx
@@ -730,4 +730,3 @@ System.out.println(d);
     </p>
   </subsection>
 </section>
-

--- a/pretext/Unit1-Using-Objects-and-Methods/topic-1-5-casting.ptx
+++ b/pretext/Unit1-Using-Objects-and-Methods/topic-1-5-casting.ptx
@@ -420,7 +420,7 @@ public class RunestoneTests extends CodeTestHelper
           </statement>
 
           <feedback>
-            <p>Did you try this out in Active Code?  Does it work that way?</p>
+            <p>Did you try this out in Active Code? Does it work that way?</p>
           </feedback>
         </choice>
 
@@ -451,7 +451,7 @@ public class RunestoneTests extends CodeTestHelper
           </statement>
 
           <feedback>
-            <p>Try casting to int instead of double.  What does that do?</p>
+            <p>Try casting to int instead of double. What does that do?</p>
           </feedback>
         </choice>
 
@@ -1005,7 +1005,7 @@ public class RunestoneTests extends CodeTestHelper
 
         <choice correct="yes">
           <statement>
-            <p>(double) total /  3;</p>
+            <p>(double) total / 3;</p>
           </statement>
 
           <feedback>

--- a/pretext/Unit1-Using-Objects-and-Methods/topic-1-5-casting.ptx
+++ b/pretext/Unit1-Using-Objects-and-Methods/topic-1-5-casting.ptx
@@ -1029,4 +1029,3 @@ public class RunestoneTests extends CodeTestHelper
     </activity>
   </subsection>
 </section>
-

--- a/pretext/Unit1-Using-Objects-and-Methods/topic-1-7-APIs-and-libraries.ptx
+++ b/pretext/Unit1-Using-Objects-and-Methods/topic-1-7-APIs-and-libraries.ptx
@@ -271,14 +271,9 @@
       operator</term> (.) is used to run an object’s methods, just like in the
       <c>System.out.println()</c> method. (If the code below does not work or is
       too slow in your browser, you can also see the <c>Turtle</c> code in
-      action at this <url href="https://replit.com/@BerylHoffman/Java-Swing-
-      Turtle#Main.java" visual="https://replit.com/@BerylHoffman/Java-Swing-
-      Turtle#Main.java">replit link</url> (refresh page after forking and if it
+      action at this <url href="https://replit.com/@BerylHoffman/Java-Swing-Turtle#Main.java">replit link</url> (refresh page after forking and if it
       gets stuck) or download the files <url
-      href="https://github.com/bhoffman0/CSAwesome2/raw/main/_sources/Unit1-Using-
-      Objects-and-Methods/TurtleJavaSwingCode.zip"
-      visual="https://github.com/bhoffman0/CSAwesome2/raw/main/_sources/Unit1-Using-
-      Objects-and-Methods/TurtleJavaSwingCode.zip">here</url> to use in your own
+      href="https://github.com/bhoffman0/CSAwesome2/raw/main/_sources/Unit1-Using-Objects-and-Methods/TurtleJavaSwingCode.zip">here</url> to use in your own
       IDE.)
     </p>
 

--- a/pretext/Unit1-Using-Objects-and-Methods/topic-1-7-APIs-and-libraries.ptx
+++ b/pretext/Unit1-Using-Objects-and-Methods/topic-1-7-APIs-and-libraries.ptx
@@ -75,8 +75,7 @@
         <p>
           How many <c>println</c> methods are there in the <c>PrintStream</c>
           class documented at <url
-          href="https://docs.oracle.com/en/java/javase/22/docs/api/java.base/java/io/PrintStream.html"
-          />?
+          href="https://docs.oracle.com/en/java/javase/22/docs/api/java.base/java/io/PrintStream.html"></url>?
         </p>
 
         <p>
@@ -271,10 +270,12 @@
       operator</term> (.) is used to run an object’s methods, just like in the
       <c>System.out.println()</c> method. (If the code below does not work or is
       too slow in your browser, you can also see the <c>Turtle</c> code in
-      action at this <url href="https://replit.com/@BerylHoffman/Java-Swing-Turtle#Main.java">replit link</url> (refresh page after forking and if it
-      gets stuck) or download the files <url
-      href="https://github.com/bhoffman0/CSAwesome2/raw/main/_sources/Unit1-Using-Objects-and-Methods/TurtleJavaSwingCode.zip">here</url> to use in your own
-      IDE.)
+      action at this <url
+      href="https://replit.com/@BerylHoffman/Java-Swing-Turtle#Main.java">replit
+      link</url> (refresh page after forking and if it gets stuck) or download
+      the files <url
+      href="https://github.com/bhoffman0/CSAwesome2/raw/main/_sources/Unit1-Using-Objects-and-Methods/TurtleJavaSwingCode.zip">here</url>
+      to use in your own IDE.)
     </p>
 
     <program language="java">

--- a/pretext/Unit1-Using-Objects-and-Methods/topic-1-7-APIs-and-libraries.ptx
+++ b/pretext/Unit1-Using-Objects-and-Methods/topic-1-7-APIs-and-libraries.ptx
@@ -73,9 +73,9 @@
     <activity label="count-println">
       <statement>
         <p>
-          How many <c>println</c> methods are there in the <c>PrintStream</c>
-          class documented at <url
-          href="https://docs.oracle.com/en/java/javase/22/docs/api/java.base/java/io/PrintStream.html"></url>?
+          How many <c>println()</c> methods are documented in the <url
+          href="https://docs.oracle.com/en/java/javase/22/docs/api/java.base/java/io/PrintStream.html">documentation
+          for the <c>PrintStream</c> class</url>?
         </p>
 
         <p>

--- a/pretext/Unit1-Using-Objects-and-Methods/topic-1-7-APIs-and-libraries.ptx
+++ b/pretext/Unit1-Using-Objects-and-Methods/topic-1-7-APIs-and-libraries.ptx
@@ -88,7 +88,11 @@
           <test>
             <strcmp use-answer="yes" />
             <feedback>
-              <p>Correct.  One for each type.</p>
+              <p>
+                Correct. One for each for nine different argument types plus one
+                that takes no arguments and just prints an end-of-line
+                character.
+              </p>
             </feedback>
           </test>
 

--- a/pretext/Unit1-Using-Objects-and-Methods/topic-1-8-comments.ptx
+++ b/pretext/Unit1-Using-Objects-and-Methods/topic-1-8-comments.ptx
@@ -137,11 +137,11 @@ public class MyClass()
     <p>
       <ul>
         <li>
-          <p>@author  Author of the program</p>
+          <p>@author Author of the program</p>
         </li>
 
         <li>
-          <p>@since   Date released</p>
+          <p>@since Date released</p>
         </li>
 
         <li>
@@ -149,11 +149,11 @@ public class MyClass()
         </li>
 
         <li>
-          <p>@param   Parameter of a method</p>
+          <p>@param Parameter of a method</p>
         </li>
 
         <li>
-          <p>@return  Return value for a method</p>
+          <p>@return Return value for a method</p>
         </li>
       </ul>
     </p>

--- a/pretext/Unit1-Using-Objects-and-Methods/topic-1-8-comments.ptx
+++ b/pretext/Unit1-Using-Objects-and-Methods/topic-1-8-comments.ptx
@@ -542,10 +542,10 @@ public class RunestoneTests extends CodeTestHelper
     <video youtube="TRcReyRYIMg" label="video-agile" />
     <p>Group Exercise</p>
     <p>
-      Try the <url href="https://www.agilesparks.com/blog/wake-up-in-the-
-      morning-game/" visual="https://www.agilesparks.com/blog/wake-up-in-the-
-      morning-game/">Wake Up In the Morning Game</url> in groups to practice the
-      iterative and incremental agile development process.
+      Try the <url
+      href="https://www.agilesparks.com/blog/wake-up-in-the-morning-game/">Wake
+      Up In the Morning Game</url> in groups to practice the iterative and
+      incremental agile development process.
     </p>
   </subsection>
 

--- a/pretext/Unit1-Using-Objects-and-Methods/unit1a-practice-coding.ptx
+++ b/pretext/Unit1-Using-Objects-and-Methods/unit1a-practice-coding.ptx
@@ -1203,4 +1203,3 @@ public class Test1
     </solution>
   </activity>
 </section>
-

--- a/pretext/Unit1-Using-Objects-and-Methods/unit1a-practice-mixed-code.ptx
+++ b/pretext/Unit1-Using-Objects-and-Methods/unit1a-practice-mixed-code.ptx
@@ -687,4 +687,3 @@
     </blocks>
   </activity>
 </section>
-

--- a/pretext/Unit1-Using-Objects-and-Methods/unit1a-summary.ptx
+++ b/pretext/Unit1-Using-Objects-and-Methods/unit1a-summary.ptx
@@ -283,10 +283,8 @@
     </activity>
 
     <p>
-      For more practice, see this <url href="https://quizlet.com/433933862/cs-
-      awesome-unit-1-vocabulary-flash-cards/"
-      visual="https://quizlet.com/433933862/cs-awesome-unit-1-vocabulary-flash-
-      cards/">Quizlet</url>.
+      For more practice, see this <url
+      href="https://quizlet.com/433933862/cs-awesome-unit-1-vocabulary-flash-cards/">Quizlet</url>.
     </p>
   </subsection>
 

--- a/pretext/Unit1-Using-Objects-and-Methods/unit1b-practice-coding.ptx
+++ b/pretext/Unit1-Using-Objects-and-Methods/unit1b-practice-coding.ptx
@@ -863,4 +863,3 @@ public class TurtleTest
     </program>
   </activity>
 </section>
-

--- a/pretext/Unit1-Using-Objects-and-Methods/unit1b-practice-mixed-code.ptx
+++ b/pretext/Unit1-Using-Objects-and-Methods/unit1b-practice-mixed-code.ptx
@@ -328,4 +328,3 @@
     </blocks>
   </activity>
 </section>
-

--- a/pretext/Unit1-Using-Objects-and-Methods/unit1b-summary.ptx
+++ b/pretext/Unit1-Using-Objects-and-Methods/unit1b-summary.ptx
@@ -347,10 +347,8 @@
     </activity>
 
     <p>
-      For more practice, see this <url href="https://quizlet.com/434063730/cs-
-      awesome-unit-2-vocabulary-flash-cards/"
-      visual="https://quizlet.com/434063730/cs-awesome-unit-2-vocabulary-flash-
-      cards/">Quizlet</url>.
+      For more practice, see this <url
+      href="https://quizlet.com/434063730/cs-awesome-unit-2-vocabulary-flash-cards/">Quizlet</url>.
     </p>
   </subsection>
 

--- a/pretext/assets/_static/css/custom.css
+++ b/pretext/assets/_static/css/custom.css
@@ -66,6 +66,11 @@ section > .para + .para {
   font-weight: 600;
 }
 
+/* I'm not sure why the .code-block:before rule exists in PtX but it just adds extra gorp. */
+.ptx-content .code-block:before {
+  content: none;
+}
+
 /* Code listings with <pre> in text washed out in Chrome */
 .ptx-content pre.program
 {


### PR DESCRIPTION
My PtX formatter used to break long line on hyphens which broke some `<url>` `href`'s. This PR fixes those URLs and fixes the formatter so it doesn't break them again in future.

I also think we can remove the `visual` attribute from `<url>` elements when it's the same as the `href` since that's what it will default to anyway. I removed the ones in the `<url>`s I had to fix here; later I'll go back and systematically fix them everywhere.