### PR TITLE
Slightly less gross way of handling the time markers.

### DIFF
--- a/pretext/Unit1-Using-Objects-and-Methods/topic-1-1-intro-algorithms.ptx
+++ b/pretext/Unit1-Using-Objects-and-Methods/topic-1-1-intro-algorithms.ptx
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <section xml:id="topic-1-1-intro-algorithms">
-  <title>
-    Introduction to Algorithms, Programming, and Compilers 
-    <image source="_static/45min.svg" />
-  </title>
+
+  <time minutes="45"/>
+
+  <title>Introduction to Algorithms, Programming, and Compilers</title>
 
   <introduction>
     <p>

--- a/pretext/Unit1-Using-Objects-and-Methods/topic-1-10-calling-class-methods.ptx
+++ b/pretext/Unit1-Using-Objects-and-Methods/topic-1-10-calling-class-methods.ptx
@@ -2,9 +2,10 @@
 
 <section xml:id="topic-1-10-calling-class-methods">
   <title>
-    Calling Class Methods 
-    <image source="_static/45min.svg" />
+    Calling Class Methods
   </title>
+
+  <time minutes="45" />
 
   <introduction>
     <p>

--- a/pretext/Unit1-Using-Objects-and-Methods/topic-1-11-Math.ptx
+++ b/pretext/Unit1-Using-Objects-and-Methods/topic-1-11-Math.ptx
@@ -2,9 +2,10 @@
 
 <section xml:id="topic-1-11-Math">
   <title>
-    Using the Math Class 
-    <image source="_static/45min.svg" />
+    Using the Math Class
   </title>
+
+  <time minutes="45" />
 
   <introduction>
     <idx>Math</idx>

--- a/pretext/Unit1-Using-Objects-and-Methods/topic-1-12-objects.ptx
+++ b/pretext/Unit1-Using-Objects-and-Methods/topic-1-12-objects.ptx
@@ -2,9 +2,10 @@
 
 <section xml:id="topic-1-12-objects">
   <title>
-    Objects - Instances of Classes 
-    <image source="_static/45min.svg" />
+    Objects - Instances of Classes
   </title>
+
+  <time minutes="45" />
 
   <introduction>
     <idx>object</idx>

--- a/pretext/Unit1-Using-Objects-and-Methods/topic-1-13-constructors.ptx
+++ b/pretext/Unit1-Using-Objects-and-Methods/topic-1-13-constructors.ptx
@@ -2,9 +2,10 @@
 
 <section xml:id="topic-1-13-constructors">
   <title>
-    Creating and Initializing Objects: Constructors 
-    <image source="_static/45min.svg" />
+    Creating and Initializing Objects: Constructors
   </title>
+
+  <time minutes="45" />
 
   <introduction>
     <idx>

--- a/pretext/Unit1-Using-Objects-and-Methods/topic-1-14-calling-instance-methods.ptx
+++ b/pretext/Unit1-Using-Objects-and-Methods/topic-1-14-calling-instance-methods.ptx
@@ -2,9 +2,10 @@
 
 <section xml:id="topic-1-14-calling-instance-methods">
   <title>
-    Calling Instance Methods 
-    <image source="_static/90min.svg" />
+    Calling Instance Methods
   </title>
+
+  <time minutes="90" />
 
   <introduction>
     <idx>instance methods</idx>
@@ -1054,9 +1055,9 @@ public class Rectangle
         // 1. Create a rectangle with width 5 and height 10
 
         // 2. Call the resize method to add 10 to its width
-        
+
         // 3. Print out its area using its getArea method
-    
+
     }
 }
         </code>

--- a/pretext/Unit1-Using-Objects-and-Methods/topic-1-15-strings.ptx
+++ b/pretext/Unit1-Using-Objects-and-Methods/topic-1-15-strings.ptx
@@ -2,9 +2,10 @@
 
 <section xml:id="topic-1-15-strings">
   <title>
-    Strings 
-    <image source="_static/90min.svg" />
+    Strings
   </title>
+
+  <time minutes="90" />
 
   <introduction>
     <idx>String</idx>

--- a/pretext/Unit1-Using-Objects-and-Methods/topic-1-2-variables.ptx
+++ b/pretext/Unit1-Using-Objects-and-Methods/topic-1-2-variables.ptx
@@ -2,9 +2,10 @@
 
 <section xml:id="topic-1-2-variables">
   <title>
-    Variables and Data Types 
-    <image source="_static/45min.svg" />
+    Variables and Data Types
   </title>
+
+  <time minutes="45" />
 
   <introduction />
   <subsection xml:id="what-is-a-variable">

--- a/pretext/Unit1-Using-Objects-and-Methods/topic-1-3-expressions.ptx
+++ b/pretext/Unit1-Using-Objects-and-Methods/topic-1-3-expressions.ptx
@@ -2,9 +2,10 @@
 
 <section xml:id="topic-1-3-expressions">
   <title>
-    Expressions and Output 
-    <image source="_static/45min.svg" />
+    Expressions and Output
   </title>
+
+  <time minutes="45" />
 
   <introduction />
   <subsection xml:id="output">

--- a/pretext/Unit1-Using-Objects-and-Methods/topic-1-4-assignment.ptx
+++ b/pretext/Unit1-Using-Objects-and-Methods/topic-1-4-assignment.ptx
@@ -2,9 +2,10 @@
 
 <section xml:id="topic-1-4-assignment">
   <title>
-    Assignment and Input 
-    <image source="_static/45min.svg" />
+    Assignment and Input
   </title>
+
+  <time minutes="45" />
 
   <introduction />
   <subsection>

--- a/pretext/Unit1-Using-Objects-and-Methods/topic-1-5-casting.ptx
+++ b/pretext/Unit1-Using-Objects-and-Methods/topic-1-5-casting.ptx
@@ -2,9 +2,10 @@
 
 <section xml:id="topic-1-5-casting">
   <title>
-    Casting and Ranges of Values 
-    <image source="_static/45min.svg" />
+    Casting and Ranges of Values
   </title>
+
+  <time minutes="45" />
 
   <introduction />
   <subsection xml:id="casting">

--- a/pretext/Unit1-Using-Objects-and-Methods/topic-1-6-compound-operators.ptx
+++ b/pretext/Unit1-Using-Objects-and-Methods/topic-1-6-compound-operators.ptx
@@ -2,9 +2,10 @@
 
 <section xml:id="topic-1-6-compound-operators">
   <title>
-    Compound Assignment Operators 
-    <image source="_static/45min.svg" />
+    Compound Assignment Operators
   </title>
+
+  <time minutes="45" />
 
   <introduction>
     <idx>compound operators</idx>

--- a/pretext/Unit1-Using-Objects-and-Methods/topic-1-7-APIs-and-libraries.ptx
+++ b/pretext/Unit1-Using-Objects-and-Methods/topic-1-7-APIs-and-libraries.ptx
@@ -2,9 +2,10 @@
 
 <section xml:id="topic-1-7-APIs-and-libraries">
   <title>
-    APIs and Libraries 
-    <image source="_static/45min.svg" />
+    APIs and Libraries
   </title>
+
+  <time minutes="45" />
 
   <introduction>
     <idx>API</idx>

--- a/pretext/Unit1-Using-Objects-and-Methods/topic-1-8-comments.ptx
+++ b/pretext/Unit1-Using-Objects-and-Methods/topic-1-8-comments.ptx
@@ -2,9 +2,10 @@
 
 <section xml:id="topic-1-8-comments">
   <title>
-    Documentation with Comments and Preconditions 
-    <image source="_static/45min.svg" />
+    Documentation with Comments and Preconditions
   </title>
+
+  <time minutes="45" />
 
   <introduction />
   <subsection xml:id="comments-1">
@@ -186,10 +187,10 @@ public class MyClass()
               Scanner scan = new Scanner(System.in);
               int num1 = scan.nextInt();
               int num2 = scan.nextInt();
-              
+
               int result = num1 * num2;
-              
-              System.out.println(num1 + " x " + num2 + " = " + result); 
+
+              System.out.println(num1 + " x " + num2 + " = " + result);
               scan.close();
          }
     }

--- a/pretext/Unit1-Using-Objects-and-Methods/topic-1-9-method-signatures.ptx
+++ b/pretext/Unit1-Using-Objects-and-Methods/topic-1-9-method-signatures.ptx
@@ -2,9 +2,10 @@
 
 <section xml:id="topic-1-9-method-signatures">
   <title>
-    Method Signatures 
-    <image source="_static/45min.svg" />
+    Method Signatures
   </title>
+
+  <time minutes="45" />
 
   <introduction />
   <subsection>
@@ -502,7 +503,7 @@ public class Song
         <cline>    <area correct="no">System.out.println("Here a </area><area correct="yes"> moo</area><area correct="no">, there a </area> <area correct="yes">  moo </area> <area correct="no">, everywhere a </area> <area correct="yes"> moo moo</area><area correct="no">");</area></cline>
         <cline>    <area correct="no">System.out.println("Old MacDonald had a farm");</area></cline>
         <cline>    <area correct="no">System.out.println("E-I-E-I-O");</area></cline>
-        <cline>    <area correct="no">System.out.println("And on this farm, they had a </area> 
+        <cline>    <area correct="no">System.out.println("And on this farm, they had a </area>
 <area correct="yes"> duck</area><area correct="no">.");</area></cline>
         <cline>    <area correct="no">System.out.println("E-I-E-I-O");</area></cline>
         <cline>    <area correct="no">System.out.println("With a </area> <area correct="yes"> quack quack </area><area correct="no"> here and a </area><area correct="yes"> quack quack </area><area correct="no"> there");</area></cline>

--- a/pretext/assets/_static/css/custom.css
+++ b/pretext/assets/_static/css/custom.css
@@ -13,19 +13,17 @@
     --codeColor: #ffaaaa;
 }
 
-/* Gross hacks to put the clock image in chapter titles. */
-span.title div.image-box {
-  display: inline-block;
-  position: static;
-  width: 100px !important;
-  float: right;
+div.time {
+    display: flex;
+    flex-direction: row;
+    width: 100%;
+    justify-content: flex-end;
+    gap: 0.25em;
+    align-items: center;
 }
 
-/* Even grosser hack to hide the image in the TOC. */
-.toc-title-box span.title div.image-box,
-.summary-links span.title div.image-box
-{
-  display: none;
+.ptx-content section > .time + * {
+    margin-top: 0.75em;
 }
 
 /* The wide style seems to add huge font size so put it down */

--- a/pretext/csawesome-pretext-style.xsl
+++ b/pretext/csawesome-pretext-style.xsl
@@ -39,19 +39,21 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
 <xsl:import href="./core/pretext-html.xsl"/>
 
-<!-- Dump some raw html blocks into output until ported to something better -->
-<xsl:template match="raw">
-  <!-- <xsl:message>==========================raw========================</xsl:message> -->
-    <xsl:copy-of select="node()"/>
+<xsl:template match="time">
+  <xsl:message>Time element processed!!!</xsl:message>
+  <div class="time">
+    <svg xmlns="http://www.w3.org/2000/svg"
+         width="16"
+         height="16"
+         fill="currentColor"
+         class="bi bi-clock"
+         viewBox="0 0 16 16">
+      <path d="M8 3.5a.5.5 0 0 0-1 0V9a.5.5 0 0 0 .252.434l3.5 2a.5.5 0 0 0 .496-.868L8 8.71V3.5z"/>
+      <path d="M8 16A8 8 0 1 0 8 0a8 8 0 0 0 0 16zm7-8A7 7 0 1 1 1 8a7 7 0 0 1 14 0z"/>
+    </svg>
+    <span> <xsl:value-of select="@minutes"/> minutes</span>
+  </div>
 </xsl:template>
-
-<!-- Comment out xrefs until conversion is done -->
-<!-- <xsl:template match="xref">
-  <xsl:message>=========================xref========================</xsl:message>
-  <xsl:comment>
-    <xsl:copy-of select="node()"/>
-  </xsl:comment>
-</xsl:template> -->
 
 <!-- Generate items that are hidden on the page -->
 <xsl:template match="hidden">

--- a/project.ptx
+++ b/project.ptx
@@ -7,7 +7,8 @@
       format="html"
       publication="html.xml"
       source="main.ptx"
-      output-dir="build/html">
+      output-dir="build/html"
+      xsl="csawesome-pretext-style.xsl">
     <stringparams author.tools="yes" html.css.extra="external/_static/css/custom.css" />
    </target>
     <target
@@ -19,11 +20,9 @@
       xsl="csawesome-pretext-style.xsl">
     <stringparams author.tools="yes" html.css.extra="external/_static/css/custom.css" />
    </target>
-    <target
-      name="print"
-      format="pdf"
-      output-filename="csawesome2.pdf" />
+   <target
+       name="print"
+       format="pdf"
+       output-filename="csawesome2.pdf" />
   </targets>
 </project>
-
-   


### PR DESCRIPTION
After I got some responses from the PtX folks to my questions, this seems like maybe a less gross way to insert some time markers. Doesn't give us total control over where they go—I'd prefer the marker goes before the title but I don't think we have that much control over how the PtX is transformed into HTML.

Or if you're happy with the other scheme, we can just leave well enough alone.