### PR TITLE
Small whitespace formatting issue

### DIFF
--- a/format-ptx.py
+++ b/format-ptx.py
@@ -119,10 +119,18 @@ def render_block(elem, ns, level=0):
         if elem.text and elem.text.strip():
             content += escape(elem.text.lstrip())
 
+        if len(elem) > 0:
+            if is_inline(elem[0]):
+                content = re.sub(r"\s+$", " ", content)
+            else:
+                content = content.rstrip()
+
         for child in elem:
             content += serialize_element(child, ns | elem.nsmap, level + 1)
             if child.tail and child.tail.strip():
                 content += escape(child.tail)
+            elif child.tail and not child.tail.strip() and is_inline(child):
+                content += " "
 
         if wrappable(elem):
             filled = fill_with_indent(content, indent(level + 1))

--- a/pretext/FreeResponse/ArrayTesterA.ptx
+++ b/pretext/FreeResponse/ArrayTesterA.ptx
@@ -75,10 +75,12 @@ public class ArrayTester
       <c>getColumn</c> method.
     </p>
 
-    <p>
-      <c>int [] [] arr2D = { { 0, 1, 2 }, { 3, 4, 5 }, { 6, 7, 8 }, { 9, 5, 3 }
-      };</c><c>int[] result = ArrayTester.getColumn (arr2D, 1);</c>
-    </p>
+    <program language="java">
+      <code>
+int [] [] arr2D = { { 0, 1, 2 }, { 3, 4, 5 }, { 6, 7, 8 }, { 9, 5, 3 }};
+int[] result = ArrayTester.getColumn (arr2D, 1);
+      </code>
+    </program>
 
     <p>
       When the code segment has completed execution, the variable result

--- a/pretext/HiddenFiles/topic-1-8-toggle-write-code.ptx
+++ b/pretext/HiddenFiles/topic-1-8-toggle-write-code.ptx
@@ -61,8 +61,8 @@ public class RunestoneTests extends CodeTestHelper
   <activity label="u1_muc_wc2">
     <statement>
       <p>
-        Write code that prints the poem <c>Roses are red</c><c>Violets are
-        blue</c><c>Sugar is sweet</c><c>And so are you</c> with 1 sentence on
+        Write code that prints the poem <c>Roses are red</c> <c>Violets are
+        blue</c> <c>Sugar is sweet</c> <c>And so are you</c> with 1 sentence on
         each line.
       </p>
     </statement>
@@ -412,7 +412,7 @@ public class RunestoneTests extends CodeTestHelper
       <p>
         Write code that prints the name on one line and the favorite food on the
         next line. Your output should look like <c>Your name is
-        Julian</c><c>Your favorite food is chicken wings</c>
+        Julian</c> <c>Your favorite food is chicken wings</c>
       </p>
     </statement>
 

--- a/pretext/HiddenFiles/topic-1-8-toggle-write-code.ptx
+++ b/pretext/HiddenFiles/topic-1-8-toggle-write-code.ptx
@@ -411,9 +411,13 @@ public class RunestoneTests extends CodeTestHelper
     <statement>
       <p>
         Write code that prints the name on one line and the favorite food on the
-        next line. Your output should look like <c>Your name is Julian</c>
-        <c>Your favorite food is chicken wings</c>
+        next line. Your output should look like:
       </p>
+
+      <pre>
+Your name is Julian
+Your favorite food is chicken wings
+      </pre>
     </statement>
 
     <program interactive="activecode" language="java">

--- a/pretext/HiddenFiles/topic-1-8-toggle-write-code.ptx
+++ b/pretext/HiddenFiles/topic-1-8-toggle-write-code.ptx
@@ -411,8 +411,8 @@ public class RunestoneTests extends CodeTestHelper
     <statement>
       <p>
         Write code that prints the name on one line and the favorite food on the
-        next line. Your output should look like <c>Your name is
-        Julian</c> <c>Your favorite food is chicken wings</c>
+        next line. Your output should look like <c>Your name is Julian</c>
+        <c>Your favorite food is chicken wings</c>
       </p>
     </statement>
 

--- a/pretext/HiddenFiles/topic-10-4-toggle-write-code.ptx
+++ b/pretext/HiddenFiles/topic-10-4-toggle-write-code.ptx
@@ -444,7 +444,7 @@ public class RunestoneTests extends CodeTestHelper
       <p>
         Write the <c>repeatThis</c> method. It should take in two parameters - a
         String <c>s</c> and an int <c>i</c> - and return a new String composed
-        of <c>s</c><c>i</c> times. For example, <c>repeatThis("Cat", 2)</c>
+        of <c>s</c> <c>i</c> times. For example, <c>repeatThis("Cat", 2)</c>
         would return <c>"CatCat"</c>.
       </p>
     </statement>

--- a/pretext/HiddenFiles/topic-8-4-toggle-write-code.ptx
+++ b/pretext/HiddenFiles/topic-8-4-toggle-write-code.ptx
@@ -394,7 +394,7 @@ public class RunestoneTests extends CodeTestHelper
       <p>
         Fill in the <c>numOccurrences</c> method. It should take in a
         two-dimension <c>int</c> array <c>nums</c> and an
-        <c>int</c><c>desired</c> and return the number of times that
+        <c>int</c> <c>desired</c> and return the number of times that
         <c>desired</c> appears in <c>nums</c>. E.g., with <c>{ {3, 1, 2}, {3, 4,
         1} }</c> as <c>nums</c>, <c>numOccurrences(nums, 1)</c> should return
         <c>2</c>.

--- a/pretext/HiddenFiles/topic-8-4-toggle-write-code.ptx
+++ b/pretext/HiddenFiles/topic-8-4-toggle-write-code.ptx
@@ -393,11 +393,10 @@ public class RunestoneTests extends CodeTestHelper
     <statement>
       <p>
         Fill in the <c>numOccurrences</c> method. It should take in a
-        two-dimension <c>int</c> array <c>nums</c> and an
-        <c>int</c> <c>desired</c> and return the number of times that
-        <c>desired</c> appears in <c>nums</c>. E.g., with <c>{ {3, 1, 2}, {3, 4,
-        1} }</c> as <c>nums</c>, <c>numOccurrences(nums, 1)</c> should return
-        <c>2</c>.
+        two-dimension <c>int</c> array <c>nums</c> and an <c>int</c>
+        <c>desired</c> and return the number of times that <c>desired</c>
+        appears in <c>nums</c>. E.g., with <c>{ {3, 1, 2}, {3, 4, 1} }</c> as
+        <c>nums</c>, <c>numOccurrences(nums, 1)</c> should return <c>2</c>.
       </p>
     </statement>
 

--- a/pretext/HiddenFiles/topic-9-10-toggle-write-code.ptx
+++ b/pretext/HiddenFiles/topic-9-10-toggle-write-code.ptx
@@ -57,7 +57,7 @@ public class RunestoneTests extends CodeTestHelper
       <p>
         Overload the <c>talk</c> method in the <c>Person</c> class so it can
         take in a String <c>name</c> and print <c>"Hello {name}!"</c> (e.g.,
-        calling <c>p.talk("Sarah")</c> on a <c>Person</c><c>p</c> would print
+        calling <c>p.talk("Sarah")</c> on a <c>Person p</c> would print
         <c>"Hello Sarah!"</c>).
       </p>
     </statement>
@@ -729,7 +729,7 @@ public class RunestoneTests extends CodeTestHelper
         calories consumed"</c>). There should also be a <c>Fruit</c> subclass
         that inherits from <c>Food</c> and adds the private <c>color</c> String
         instance variable. The <c>Fruit</c> class should override the
-        <c>Food</c><c>chomp()</c> method to return nothing, print
+        <c>Food</c> <c>chomp()</c> method to return nothing, print
         <c>"{numCalories} calories consumed"</c>, and print <c>"the fruit is
         {color}"</c> (on a new line). Finally, there should be an <c>Apple</c>
         subclass that inherits from <c>Fruit</c>, sets <c>color</c> to

--- a/pretext/Unit1-Using-Objects-and-Methods/topic-1-13-constructors.ptx
+++ b/pretext/Unit1-Using-Objects-and-Methods/topic-1-13-constructors.ptx
@@ -55,7 +55,7 @@ Turtle t = new Turtle(habitat); // create a new Turtle object
     </figure>
 
     <p>
-      The <term>no-argument constructor</term><c>World()</c>, with no arguments
+      The <term>no-argument constructor</term> <c>World()</c>, with no arguments
       inside the parentheses following the name of the constructor, creates a
       graphical window with a default size of 640x480 pixels. No-argument
       constructors usually set the attributes of the object to default values.

--- a/pretext/Unit1-Using-Objects-and-Methods/topic-1-8-comments.ptx
+++ b/pretext/Unit1-Using-Objects-and-Methods/topic-1-8-comments.ptx
@@ -49,10 +49,9 @@
     </p>
 
     <p>
-      There is also a special version of the multi-line comment,
-      <c>/**</c><c>*/</c>, called the documentation comment. Java has a cool
-      tool called <url
-      href="https://www.tutorialspoint.com/java/java_documentation.htm"
+      There is also a special version of the multi-line comment, <c>/**</c> ...
+      <c>*/</c>, called the documentation comment. Java has a cool tool called
+      <url href="https://www.tutorialspoint.com/java/java_documentation.htm"
       visual="https://www.tutorialspoint.com/java/java_documentation.htm">javadoc</url>
       that comes with the <url
       href="https://www.oracle.com/technetwork/java/javase/downloads/index.html"

--- a/pretext/Unit2-Selection-and-Iteration/selection-summary.ptx
+++ b/pretext/Unit2-Selection-and-Iteration/selection-summary.ptx
@@ -43,9 +43,8 @@
         <li>
           <p>
             <term>compound Boolean expressions</term> - A Boolean expression
-            with two or more conditions joined by a logical
-            <term>and</term><c>&amp;&amp;</c> or a logical
-            <term>or</term><c>||</c>.
+            with two or more conditions joined by a logical <term>and</term>
+            <c>&amp;&amp;</c> or a logical <term>or</term> <c>||</c>.
           </p>
         </li>
 

--- a/pretext/Unit2-Selection-and-Iteration/topic-2-10-strings-loops.ptx
+++ b/pretext/Unit2-Selection-and-Iteration/topic-2-10-strings-loops.ptx
@@ -97,7 +97,7 @@
   <subsection xml:id="while-find-and-replace-loop">
     <title>While Find and Replace Loop</title>
     <p>
-      A while loop can be used with the <c>String</c><c>indexOf</c> method to
+      A while loop can be used with the <c>String</c> <c>indexOf</c> method to
       find certain characters in a string and process them, usually using the
       <c>substring</c> method.
     </p>

--- a/pretext/Unit4-Data-Collections/a2dSummary.ptx
+++ b/pretext/Unit4-Data-Collections/a2dSummary.ptx
@@ -66,7 +66,7 @@
             type of elements that will be stored in the array, then
             (<c>[][]</c>) to show that it is a 2d array of that type, then at
             least one space, and then a name for the array. Examples: <c>int[][]
-            seats;</c><c>String[][] seatingChart;</c>
+            seats;</c> <c>String[][] seatingChart;</c>
           </p>
         </li>
 

--- a/pretext/Unit4-Data-Collections/array-summary.ptx
+++ b/pretext/Unit4-Data-Collections/array-summary.ptx
@@ -81,7 +81,7 @@
             type of elements that will be stored in the array, then (<c>[]</c>)
             to show that it is an array of that type, then at least one space,
             and then a name for the array. Examples: <c>int[]
-            highScores;</c><c>String[] names;</c>
+            highScores;</c> <c>String[] names;</c>
           </p>
         </li>
 

--- a/pretext/Unit4-Data-Collections/array-summary.ptx
+++ b/pretext/Unit4-Data-Collections/array-summary.ptx
@@ -80,8 +80,8 @@
             <term>Array Declaration</term> - To declare an array specify the
             type of elements that will be stored in the array, then (<c>[]</c>)
             to show that it is an array of that type, then at least one space,
-            and then a name for the array. Examples: <c>int[]
-            highScores;</c> <c>String[] names;</c>
+            and then a name for the array. Examples: <c>int[] highScores;</c>
+            <c>String[] names;</c>
           </p>
         </li>
 

--- a/pretext/Unit4-Data-Collections/topic-4-9-arraylist-traversal.ptx
+++ b/pretext/Unit4-Data-Collections/topic-4-9-arraylist-traversal.ptx
@@ -632,8 +632,8 @@ public class RunestoneTests extends CodeTestHelper
     <program language="java">
       <code>
        // get the name of the 0's student
-       String name = students.get(0).getName();    
-       // get the GPA of the student at index i 
+       String name = students.get(0).getName();
+       // get the GPA of the student at index i
        double gpa = students.get(i).getGPA();
       </code>
     </program>
@@ -650,7 +650,7 @@ public class RunestoneTests extends CodeTestHelper
         <code>
 import java.util.*;
 
-public class Roster 
+public class Roster
 {
     private ArrayList&lt;Student&gt; list = new ArrayList&lt;Student&gt;();
 
@@ -667,18 +667,18 @@ public class Roster
     // implicitly calling the toString() method of the Student class.
     public void printRoster()
     {
-       
+
     }
 
-    // Write a honorRoll() method to print the names of students 
-    // with a GPA greater than 3.5 on the list using an indexed for loop with index i 
+    // Write a honorRoll() method to print the names of students
+    // with a GPA greater than 3.5 on the list using an indexed for loop with index i
     // and chaining get(i) with the getGPA() and getName() methods of the Student class.
     public void honorRoll()
     {
-        
+
     }
-    
-    
+
+
     // main method for testing
     public static void main(String[] args)
     {
@@ -695,7 +695,7 @@ class Student
     private String name;
     private int id;
     private double gpa;
-    
+
 
     public Student(String name, int id, double gpa)
     {
@@ -941,8 +941,8 @@ class WordPair
                     <li>
                       <p>
                         Add the new <c>WordPair</c> formed from the <c>i</c>th
-                        word and the <c>j</c>th word to the
-                        <c>allPairs</c><c>ArrayList</c>.
+                        word and the <c>j</c>th word to the <c>allPairs</c>
+                        <c>ArrayList</c>.
                       </p>
                     </li>
                   </ul>
@@ -1124,7 +1124,7 @@ class WordPair
 
     <p>
       For this method, you will need a loop that goes through the
-      <c>ArrayList</c><c>allPairs</c> and for each <c>WordPair</c> in
+      <c>ArrayList</c> <c>allPairs</c> and for each <c>WordPair</c> in
       <c>allPairs</c>, it checks to see if its first word (using the
       <c>getFirst</c> method) equals the second word (using the <c>getSecond</c>
       method). If there is a match, it increments a counter which it returns at

--- a/pretext/Unit5-Inheritance/ooParsonsPractice.ptx
+++ b/pretext/Unit5-Inheritance/ooParsonsPractice.ptx
@@ -518,7 +518,7 @@
         calories consumed"</c> (e.g., <c>"5 calories consumed"</c>). There
         should also be a <c>Fruit</c> subclass that inherits from <c>Food</c>
         and adds the private <c>color</c> String instance variable. The
-        <c>Fruit</c> class should override the <c>Food</c><c>chomp()</c> method
+        <c>Fruit</c> class should override the <c>Food</c> <c>chomp()</c> method
         to return nothing, print <c>"{numCalories} calories consumed"</c>, and
         print <c>"fruit is {color}"</c> (on a new line). Finally, there should
         be an <c>Apple</c> subclass that inherits from <c>Fruit</c>, sets

--- a/pretext/Unit5-Inheritance/topic-5-4-super.ptx
+++ b/pretext/Unit5-Inheritance/topic-5-4-super.ptx
@@ -44,7 +44,7 @@
     <p>
       In the example below, the <c>Student</c> class overrides the
       <c>getFood</c> method of the <c>Person</c> class, and it uses
-      <c>super.getFood()</c> to call the <c>Person</c><c>getFood</c> method
+      <c>super.getFood()</c> to call the <c>Person</c> <c>getFood</c> method
       before adding on to it. Here, a <c>Person</c> is associated with the food
       “Hamburger” and a <c>Student</c> is associated with “Hamburger” and
       “Taco”.

--- a/pretext/Unit5-Inheritance/topic-5-5-hierarchies.ptx
+++ b/pretext/Unit5-Inheritance/topic-5-5-hierarchies.ptx
@@ -552,7 +552,7 @@ class Dog extends Pet
       In this challenge, you will add a new class called <c>DiscountedItem</c>
       that extends the <c>Item</c> class. The <c>ArrayList</c> of <c>Item</c>
       will still work since it can hold the subclasses of <c>Item</c> too! The
-      <c>ShoppingCart</c><c>printOrder</c> method will work with <c>Item</c> and
+      <c>ShoppingCart</c> <c>printOrder</c> method will work with <c>Item</c> and
       <c>DiscountedItem</c> but note that it has an <c>if</c> statement that
       treats <c>DiscountedItem</c> differently.
     </p>

--- a/pretext/Unit5-Inheritance/topic-5-5-hierarchies.ptx
+++ b/pretext/Unit5-Inheritance/topic-5-5-hierarchies.ptx
@@ -552,8 +552,8 @@ class Dog extends Pet
       In this challenge, you will add a new class called <c>DiscountedItem</c>
       that extends the <c>Item</c> class. The <c>ArrayList</c> of <c>Item</c>
       will still work since it can hold the subclasses of <c>Item</c> too! The
-      <c>ShoppingCart</c> <c>printOrder</c> method will work with <c>Item</c> and
-      <c>DiscountedItem</c> but note that it has an <c>if</c> statement that
+      <c>ShoppingCart</c> <c>printOrder</c> method will work with <c>Item</c>
+      and <c>DiscountedItem</c> but note that it has an <c>if</c> statement that
       treats <c>DiscountedItem</c> differently.
     </p>
 

--- a/pretext/bookinfo.ptx
+++ b/pretext/bookinfo.ptx
@@ -1,15 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <docinfo>
-  <document-id>csawesome2</document-id>
-  <!-- Rename Checkpoint for exercise to Activity -->
+  <document-id>csawesome2</document-id><!-- Rename Checkpoint for exercise to Activity -->
   <rename element="inlineexercise">Activity</rename>
   <rename element="chapter">Unit</rename>
   <brandlogo url="./index.html" source="_static/CSAwesomeLogo.png" alt="CSAwesome" />
   <blurb shelf="AP Computer Science">
     CSAwesome2 is the newest AP CSA Java curriculum approved to meet the 2025-2026 College Board standards and an introductory college-level computer programming course in Java.
   </blurb>
-  <!-- this is the default, but supresses a warning -->
+<!-- this is the default, but supresses a warning -->
   <cross-references text="type-global" />
   <programs language="java" />
   <parsons language="java" />

--- a/test-idempotency.sh
+++ b/test-idempotency.sh
@@ -3,10 +3,13 @@
 set -euo pipefail
 
 ./format-ptx.py "$1" > first.xml
-./format-ptx.py first.xml > second.xml
+./format-ptx.py -q first.xml > second.xml
 sum1=$(shasum first.xml | cut -c -40)
 sum2=$(shasum second.xml | cut -c -40)
 
 if [ "$sum1" != "$sum2" ]; then
     echo "$1"
+    exit 1
+else
+    exit 0
 fi


### PR DESCRIPTION
I noticed that `format-ptx` was squashing out whitespace between consecutive inline elements. I fixed it so it doesn't do that anymore and I think I found most/all of the places where it did it and fixed them.