### PR TITLE
Adding section to quiz bank exercises page

### DIFF
--- a/pretext/Exercises.ptx
+++ b/pretext/Exercises.ptx
@@ -1,10 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<chapter xml:id="Exercises" xml:lang="en-US" xmlns:xi="http://www.w3.org/2001/XInclude">
+<chapter xml:id="QBunit" xml:lang="en-US" xmlns:xi="http://www.w3.org/2001/XInclude">
+  <title>Quiz Bank Exercises Unit</title>
+  <section xml:id="Exercises">
   <title>Quiz Bank Exercises</title>
   <p>
     The quiz bank is available for instructors to use under the Instructor's
     page in Runestone custom courses. Instructors should choose this chapter
     when making new exercises.
   </p>
+</section>
 </chapter>


### PR DESCRIPTION
Adding a section with xml:id Exercises should allow teacher-contributed exercises in the assignment page to be attached to it.