### PR TITLE
Fix dictionary file count

### DIFF
--- a/pretext/Unit4-Data-Collections/topic-4-4-array-traversal.ptx
+++ b/pretext/Unit4-Data-Collections/topic-4-4-array-traversal.ptx
@@ -1694,8 +1694,7 @@ class Student
     </p>
 
     <datafile label="dictionary" filename="dictionary.txt" editable="no" hide="yes">
-      <pre>
-        
+      <pre>        
 a
 aa
 aaa
@@ -11698,7 +11697,7 @@ zshops
 zu
 zum
 zus
-      </pre>
+</pre>
     </datafile>
 
     <project label="challenge-spellchecker">

--- a/pretext/Unit4-Data-Collections/topic-4-6-input-files.ptx
+++ b/pretext/Unit4-Data-Collections/topic-4-6-input-files.ptx
@@ -440,7 +440,7 @@ public class RunestoneTests extends CodeTestHelper
     public void testMain() throws IOException
     {
         String output = getMethodOutput("main");
-        String expect = "This file has 10000 lines.";
+        String expect = "This file has 10002 lines.";
         boolean passed = getResults(expect, output, "Expected output from main");
         assertTrue(passed);
     }

--- a/pretext/assets/_static/dictionary10K.txt
+++ b/pretext/assets/_static/dictionary10K.txt
@@ -258,6 +258,7 @@ alarm
 alaska
 albania
 albany
+albatross
 albert
 alberta
 album
@@ -9981,6 +9982,7 @@ za
 zambia
 zdnet
 zealand
+zebra
 zen
 zero
 zimbabwe


### PR DESCRIPTION
I added 2 words to the dictionary in 4-4 for the search lesson awhile ago, but forgot about the exercise that counts the lines in 4-6. Fixed test here after a teacher reported the error. I also fixed the file dictionary10K to match in case reading it from that file directly ever works. 