### PR TITLE
Update all links to AP CSA Quick Reference Sheet

### DIFF
--- a/pretext/Unit1-Using-Objects-and-Methods/topic-1-11-Math.ptx
+++ b/pretext/Unit1-Using-Objects-and-Methods/topic-1-11-Math.ptx
@@ -85,9 +85,8 @@
       <p>
         All the <c>Math</c> methods that you may need to use or understand on
         the AP exam are listed in the <url
-        href="https://apstudents.collegeboard.org/ap/pdf/ap-computer-science-a-java-quick-reference_0.pdf"
-        visual="https://apstudents.collegeboard.org/ap/pdf/ap-computer-science-a-java-quick-reference_0.pdf">AP CSA Java Quick Reference Sheet</url>
-        that you can use during the exam.
+        href="https://drive.google.com/file/d/1UL4JeQ5hfnO3H6uoZizgOU2XjHkitmFw/view?usp=sharing">AP
+        CSA Java Quick Reference Sheet</url> that you can use during the exam.
       </p>
     </note>
 

--- a/pretext/Unit1-Using-Objects-and-Methods/topic-1-15-strings.ptx
+++ b/pretext/Unit1-Using-Objects-and-Methods/topic-1-15-strings.ptx
@@ -562,9 +562,9 @@ public class RunestoneTests extends CodeTestHelper
       The <c>String</c> class includes many methods to process strings. For the
       AP CSA exam, you only need to know how to use the following String
       methods. Their descriptions are included in the <url
-      href="https://apstudents.collegeboard.org/ap/pdf/ap-computer-science-a-java-quick-reference_0.pdf"
-      visual="https://apstudents.collegeboard.org/ap/pdf/ap-computer-science-a-java-quick-reference_0.pdf">AP CSA Java Quick Reference Sheet</url> that
-      you get during the exam so you don’t have to memorize these.
+      href="https://drive.google.com/file/d/1UL4JeQ5hfnO3H6uoZizgOU2XjHkitmFw/view?usp=sharing">AP
+      CSA Java Quick Reference Sheet</url> that you get during the exam so you
+      don’t have to memorize these.
     </p>
 
     <blockquote>
@@ -1540,9 +1540,9 @@ public class RunestoneTests extends CodeTestHelper
           <p>
             (AP 1.15.B.2) The following String methods and constructors,
             including what they do and when they are used, are part of the <url
-            href="https://apstudents.collegeboard.org/ap/pdf/ap-computer-science-a-java-quick-reference_0.pdf"
-            visual="https://apstudents.collegeboard.org/ap/pdf/ap-computer-science-a-java-quick-reference_0.pdf">AP CSA Java Quick Reference
-            Sheet</url> that you can use during the exam:
+            href="https://drive.google.com/file/d/1UL4JeQ5hfnO3H6uoZizgOU2XjHkitmFw/view?usp=sharing">AP
+            CSA Java Quick Reference Sheet</url> that you can use during the
+            exam:
           </p>
 
           <p>

--- a/pretext/Unit2-Selection-and-Iteration/topic-2-10-strings-loops.ptx
+++ b/pretext/Unit2-Selection-and-Iteration/topic-2-10-strings-loops.ptx
@@ -54,8 +54,7 @@
 
     <p>
       The String methods (covered in a previous lesson and given in the <url
-      href="https://apstudents.collegeboard.org/ap/pdf/ap-computer-science-a-java-quick-reference_0.pdf"
-      visual="https://apstudents.collegeboard.org/ap/pdf/ap-computer-science-a-java-quick-reference_0.pdf">AP
+      href="https://drive.google.com/file/d/1UL4JeQ5hfnO3H6uoZizgOU2XjHkitmFw/view?usp=sharing">AP
       CSA Java Quick Reference Sheet</url>) that are most often used to process
       strings are:
     </p>

--- a/pretext/Unit4-Data-Collections/topic-4-8-arraylists.ptx
+++ b/pretext/Unit4-Data-Collections/topic-4-8-arraylists.ptx
@@ -478,8 +478,7 @@ ArrayList&lt;Student&gt; roster = new ArrayList&lt;Student&gt;();
     <p>
       The following are the <c>ArrayList</c> methods that you need to know for
       the AP CSA exam. These are included on the <url
-      href="https://apstudents.collegeboard.org/ap/pdf/ap-computer-science-a-java-quick-reference_0.pdf"
-      visual="https://apstudents.collegeboard.org/ap/pdf/ap-computer-science-a-java-quick-reference_0.pdf">AP
+      href="https://drive.google.com/file/d/1UL4JeQ5hfnO3H6uoZizgOU2XjHkitmFw/view?usp=sharing">AP
       CSA Java Quick Reference Sheet</url> that you will receive during the exam
       so you do not need to memorize them. The E in the method headers below
       stands for the type of the element in the ArrayList; this type E can be

--- a/pretext/Unit5-Inheritance/topic-5-7-Object.ptx
+++ b/pretext/Unit5-Inheritance/topic-5-7-Object.ptx
@@ -10,8 +10,7 @@
       specified using the <c>extends</c> keyword, the class will inherit from
       the <c>Object</c> class. What does a class inherit from the <c>Object</c>
       class? The <url
-      href="https://apstudents.collegeboard.org/ap/pdf/ap-computer-science-a-java-quick-reference_0.pdf"
-      visual="https://apstudents.collegeboard.org/ap/pdf/ap-computer-science-a-java-quick-reference_0.pdf">AP
+      href="https://drive.google.com/file/d/1UL4JeQ5hfnO3H6uoZizgOU2XjHkitmFw/view?usp=sharing">AP
       CSA Java Quick Reference Sheet</url> lists the two main methods that are
       most frequently used:
     </p>


### PR DESCRIPTION
Noticed that not all the links to the Quick Reference had been updated to the new one.